### PR TITLE
Call account-requests endpoint after obtaining access-token

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,7 @@ DEBUG=error,log,debug
 ASPSP_AUTH_SERVER=http://localhost:8001
 ASPSP_AUTH_SERVER_CLIENT_ID=spoofClientId
 ASPSP_AUTH_SERVER_CLIENT_SECRET=spoofClientSecret
+ASPSP_RESOURCE_SERVER=http://localhost:8001
 ASPSP_READWRITE_HOST=localhost:8001
 OB_PROVISIONED=false
 OB_DIRECTORY_HOST=http://localhost:8001

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ heroku config:set X_FAPI_FINANCIAL_ID=<mock-id>
 heroku config:set DEBUG=error,log
 heroku config:set OB_PROVISIONED=false
 heroku config:set OB_DIRECTORY_HOST=http://example.com
+heroku config:set ASPSP_RESOURCE_SERVER=http://example.com
+heroku config:set ASPSP_AUTH_SERVER=http://example.com
+heroku config:set ASPSP_AUTH_SERVER_CLIENT_ID=spoofClientId
+heroku config:set ASPSP_AUTH_SERVER_CLIENT_SECRET=spoofClientSecret
 
 git push heroku master
 ```

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -6,8 +6,9 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId } = req.body;
+    const fapiFinancialId = req.headers['x-fapi-financial-id'];
     debug(`authorisationServerId: ${authorisationServerId}`);
-    await setupAccountRequest(authorisationServerId);
+    await setupAccountRequest(authorisationServerId, fapiFinancialId);
     return res.status(204).send();
   } catch (err) {
     error(err);

--- a/app/obtain-access-token.js
+++ b/app/obtain-access-token.js
@@ -20,7 +20,7 @@ const postToken = async (authorisationServerHost, clientId, clientSecret, payloa
     const authCredentials = credentials(clientId, clientSecret);
     log(`POST to ${tokenUri}`);
     const response = await request
-      .post(`${authorisationServerHost}/token`)
+      .post(tokenUri)
       .set('authorization', authCredentials)
       .set('content-type', 'application/x-www-form-urlencoded')
       .send(payload);

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -25,7 +25,7 @@ const buildAccountRequestData = () => ({
  * @resourceServerPath e.g. http://example.com/open-banking/v1.1
  */
 const postAccountRequests = async (resourceServerPath, accessToken,
-  fapiFinancialId, jwsSignature) => {
+  fapiFinancialId) => {
   try {
     const body = buildAccountRequestData();
     const accountRequestsUri = `${resourceServerPath}/account-requests`;
@@ -36,7 +36,7 @@ const postAccountRequests = async (resourceServerPath, accessToken,
       .set('content-type', 'application/json; charset=utf-8')
       .set('accept', 'application/json; charset=utf-8')
       .set('x-fapi-financial-id', fapiFinancialId)
-      .set('x-jws-signature', jwsSignature)
+      .set('x-jws-signature', 'not-required-swagger-to-be-changed')
       .send(body);
     return response.body;
   } catch (err) {

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -1,0 +1,50 @@
+const request = require('superagent');
+const log = require('debug')('log');
+
+const buildAccountRequestData = () => ({
+  Data: {
+    Permissions: [
+      'ReadAccountsDetail',
+      'ReadBalances',
+      'ReadBeneficiariesDetail',
+      'ReadDirectDebits',
+      'ReadProducts',
+      'ReadStandingOrdersDetail',
+      'ReadTransactionsCredits',
+      'ReadTransactionsDebits',
+      'ReadTransactionsDetail',
+    ],
+    // ExpirationDateTime: // not populated - the permissions will be open ended
+    // TransactionFromDateTime: // not populated - request from the earliest available transaction
+    // TransactionToDateTime: // not populated - request to the latest available transactions
+  },
+});
+
+/*
+ * For now only support Client Credentials Grant Type (OAuth 2.0).
+ * @resourceServerPath e.g. http://example.com/open-banking/v1.1
+ */
+const postAccountRequests = async (resourceServerPath, accessToken,
+  fapiFinancialId, jwsSignature) => {
+  try {
+    const body = buildAccountRequestData();
+    const accountRequestsUri = `${resourceServerPath}/account-requests`;
+    log(`POST to ${accountRequestsUri}`);
+    const response = await request
+      .post(accountRequestsUri)
+      .set('authorization', `Bearer ${accessToken}`)
+      .set('content-type', 'application/json; charset=utf-8')
+      .set('accept', 'application/json; charset=utf-8')
+      .set('x-fapi-financial-id', fapiFinancialId)
+      .set('x-jws-signature', jwsSignature)
+      .send(body);
+    return response.body;
+  } catch (err) {
+    const error = new Error(err.message);
+    error.status = err.response ? err.response.status : 500;
+    throw error;
+  }
+};
+
+exports.buildAccountRequestData = buildAccountRequestData;
+exports.postAccountRequests = postAccountRequests;

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -37,6 +37,7 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
   }
 };
 
+// Returns access-token when request successful
 const createAccessToken = async (authorisationServerId) => {
   const authorisationServer = await authorisationServerHost(authorisationServerId);
   const { clientId, clientSecret } = await clientCredentials(authorisationServerId);
@@ -54,16 +55,25 @@ const createAccessToken = async (authorisationServerId) => {
   return response.access_token;
 };
 
+// Returns accountRequestId when request successful
 const createAccountRequest = async (authorisationServerId, accessToken, fapiFinancialId) => {
   const resourceServer = await resourceServerHost(authorisationServerId);
-  return postAccountRequests(resourceServer, accessToken, fapiFinancialId);
+  const response = postAccountRequests(resourceServer, accessToken, fapiFinancialId);
+  if (response.Data && response.Data.Status === 'AwaitingAuthorisation') {
+    return response.Data.AccountRequestId;
+  }
+  return null;
 };
 
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
   validateParameters(authorisationServerId, fapiFinancialId);
   const accessToken = await createAccessToken(authorisationServerId);
-  await createAccountRequest(authorisationServerId, accessToken, fapiFinancialId);
-  return accessToken;
+  const accountRequestId = await createAccountRequest(
+    authorisationServerId,
+    accessToken,
+    fapiFinancialId,
+  );
+  return accountRequestId;
 };
 
 exports.setupAccountRequest = setupAccountRequest;

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -37,8 +37,7 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
   }
 };
 
-const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
-  validateParameters(authorisationServerId, fapiFinancialId);
+const createAccessToken = async (authorisationServerId) => {
   const authorisationServer = await authorisationServerHost(authorisationServerId);
   const { clientId, clientSecret } = await clientCredentials(authorisationServerId);
   const accessTokenPayload = {
@@ -52,9 +51,18 @@ const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
     clientSecret,
     accessTokenPayload,
   );
-  const accessToken = response.access_token;
+  return response.access_token;
+};
+
+const createAccountRequest = async (authorisationServerId, accessToken, fapiFinancialId) => {
   const resourceServer = await resourceServerHost(authorisationServerId);
-  postAccountRequests(resourceServer, accessToken, fapiFinancialId);
+  return postAccountRequests(resourceServer, accessToken, fapiFinancialId);
+};
+
+const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
+  validateParameters(authorisationServerId, fapiFinancialId);
+  const accessToken = await createAccessToken(authorisationServerId);
+  await createAccountRequest(authorisationServerId, accessToken, fapiFinancialId);
   return accessToken;
 };
 

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -18,13 +18,23 @@ const clientCredentials = async authorisationServerId => {
   return authorisationServerId ? credentials : null;
 };
 
-// eslint-disable-next-line arrow-parens
-const setupAccountRequest = async authorisationServerId => {
-  if (!authorisationServerId) {
-    const error = new Error('authorisationServerId missing from request payload');
+const validateParameters = (authorisationServerId, fapiFinancialId) => {
+  let error;
+  if (!fapiFinancialId) {
+    error = new Error('fapiFinancialId missing from request payload');
     error.status = 400;
+  }
+  if (!authorisationServerId) {
+    error = new Error('authorisationServerId missing from request payload');
+    error.status = 400;
+  }
+  if (error) {
     throw error;
   }
+};
+
+const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
+  validateParameters(authorisationServerId, fapiFinancialId);
   const authorizationServerHost = await authorisationServerHost(authorisationServerId);
   const { clientId, clientSecret } = await clientCredentials(authorisationServerId);
   const accessTokenPayload = {

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,4 +1,5 @@
 const { postToken } = require('../obtain-access-token');
+const { postAccountRequests } = require('./account-requests');
 const env = require('env-var');
 
 const authServer = env.get('ASPSP_AUTH_SERVER').asString();
@@ -8,9 +9,12 @@ const authServerClientSecret = env.get('ASPSP_AUTH_SERVER_CLIENT_SECRET').asStri
 // Todo: lookup auth server via Directory and OpenIdEndpoint responses.
 const authorisationServerHost = async authServerId => (authServerId ? authServer : null);
 
+// Todo: lookup resource server via Directory and OpenIdEndpoint responses.
+const resourceServerHost = async authorisationServerId =>
+  (authorisationServerId ? env.get('ASPSP_RESOURCE_SERVER').asString() : null);
+
 // Todo: retrieve clientCredentials from store keyed by authorisationServerId.
-// eslint-disable-next-line arrow-parens
-const clientCredentials = async authorisationServerId => {
+const clientCredentials = async (authorisationServerId) => {
   const credentials = {
     clientId: authServerClientId,
     clientSecret: authServerClientSecret,
@@ -35,7 +39,7 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
 
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
   validateParameters(authorisationServerId, fapiFinancialId);
-  const authorizationServerHost = await authorisationServerHost(authorisationServerId);
+  const authorisationServer = await authorisationServerHost(authorisationServerId);
   const { clientId, clientSecret } = await clientCredentials(authorisationServerId);
   const accessTokenPayload = {
     scope: 'accounts',
@@ -43,12 +47,14 @@ const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
   };
 
   const response = await postToken(
-    authorizationServerHost,
+    authorisationServer,
     clientId,
     clientSecret,
     accessTokenPayload,
   );
   const accessToken = response.access_token;
+  const resourceServer = await resourceServerHost(authorisationServerId);
+  postAccountRequests(resourceServer, accessToken, fapiFinancialId);
   return accessToken;
 };
 

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -38,7 +38,8 @@ const setupAccountRequest = async authorisationServerId => {
     clientSecret,
     accessTokenPayload,
   );
-  return response.access_token;
+  const accessToken = response.access_token;
+  return accessToken;
 };
 
 exports.setupAccountRequest = setupAccountRequest;

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -24,7 +24,7 @@ describe('Setup account request POST /account-requests 201 response', () => {
 
   const accessToken = '2YotnFZFEjr1zCsicMWpAA';
   const fapiFinancialId = 'abc';
-  const jwsSignature = 'sig';
+  const jwsSignature = 'not-required-swagger-to-be-changed';
 
   nock(/example\.com/)
     .post('/open-banking/v1.1/account-requests')
@@ -42,7 +42,6 @@ describe('Setup account request POST /account-requests 201 response', () => {
       resourceServerPath,
       accessToken,
       fapiFinancialId,
-      jwsSignature,
     );
     assert.deepEqual(result, response);
   });

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -1,0 +1,49 @@
+const { postAccountRequests, buildAccountRequestData } = require('../../app/setup-account-request/account-requests');
+const assert = require('assert');
+
+const nock = require('nock');
+
+describe('Setup account request POST /account-requests 201 response', () => {
+  const requestBody = buildAccountRequestData();
+  const accountRequestId = '88379';
+  const response = {
+    Data: {
+      AccountRequestId: accountRequestId,
+      Status: 'AwaitingAuthentication',
+      CreationDateTime: (new Date()).toISOString(),
+      Permissions: requestBody.Data.Permissions,
+    },
+    Risk: {},
+    Links: {
+      self: `/account-requests/${accountRequestId}`,
+    },
+    Meta: {
+      'total-pages': 1,
+    },
+  };
+
+  const accessToken = '2YotnFZFEjr1zCsicMWpAA';
+  const fapiFinancialId = 'abc';
+  const jwsSignature = 'sig';
+
+  nock(/example\.com/)
+    .post('/open-banking/v1.1/account-requests')
+    .matchHeader('authorization', `Bearer ${accessToken}`) // required
+    .matchHeader('x-fapi-financial-id', fapiFinancialId) // required
+    .matchHeader('x-jws-signature', jwsSignature) // required
+    // optional x-fapi-customer-last-logged-time
+    // optional x-fapi-customer-ip-address
+    // optional x-fapi-interaction-id
+    .reply(201, response);
+
+  it('returns data when 201 OK', async () => {
+    const resourceServerPath = 'http://example.com/open-banking/v1.1';
+    const result = await postAccountRequests(
+      resourceServerPath,
+      accessToken,
+      fapiFinancialId,
+      jwsSignature,
+    );
+    assert.deepEqual(result, response);
+  });
+});

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 
 const nock = require('nock');
 
-describe('Setup account request POST /account-requests 201 response', () => {
+describe('postAccountRequests', () => {
   const requestBody = buildAccountRequestData();
   const accountRequestId = '88379';
   const response = {

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -31,28 +31,42 @@ describe('setupAccountRequest called with blank fapiFinancialId', () => {
   });
 });
 
-describe('setupAccountRequest called with authorisationServerId', () => {
+describe('setupAccountRequest called with authorisationServerId and fapiFinancialId', () => {
   const accessToken = 'access-token';
+  const awaitingAuthorisation = 'AwaitingAuthorisation';
   const authServerHost = 'http://example.com';
+  const resourceServerPath = 'http://example.com/resources';
   const clientId = 'id';
   const clientSecret = 'secret';
   const tokenPayload = {
     scope: 'accounts',
     grant_type: 'client_credentials',
   };
+  const accountRequestId = '88379';
 
   let setupAccountRequestProxy;
   let postTokenStub;
+  let postAccountRequestsStub;
+  const tokenResponse = { access_token: accessToken };
+  const accountRequestsResponse = {
+    Data: {
+      AccountRequestId: accountRequestId,
+      Status: awaitingAuthorisation,
+    },
+  };
 
   before(() => {
-    postTokenStub = sinon.stub().returns({ access_token: accessToken });
+    postTokenStub = sinon.stub().returns(tokenResponse);
+    postAccountRequestsStub = sinon.stub().returns(accountRequestsResponse);
     setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
       'env-var': env.mock({
         ASPSP_AUTH_SERVER: authServerHost,
         ASPSP_AUTH_SERVER_CLIENT_ID: clientId,
         ASPSP_AUTH_SERVER_CLIENT_SECRET: clientSecret,
+        ASPSP_RESOURCE_SERVER: resourceServerPath,
       }),
       '../obtain-access-token': { postToken: postTokenStub },
+      './account-requests': { postAccountRequests: postAccountRequestsStub },
     }).setupAccountRequest;
   });
 
@@ -60,5 +74,10 @@ describe('setupAccountRequest called with authorisationServerId', () => {
     const token = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
     assert.equal(token, accessToken);
     assert(postTokenStub.calledWithExactly(authServerHost, clientId, clientSecret, tokenPayload));
+    assert(postAccountRequestsStub.calledWithExactly(
+      resourceServerPath,
+      accessToken,
+      fapiFinancialId,
+    ));
   });
 });


### PR DESCRIPTION
Add function to POST to `/account-requests` endpoint.

Return accountRequestId from setupAccountRequest function:
- When `/account-requests` response status is `AwaitingAuthorisation` return accountRequestId.
- When `/account-requests` response status is `Rejected` return null for accountRequestId.

Completes: #CDRW-806