### PR TITLE
Updates for release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Or run with environment variables set on the command line:
 
 ```sh
 DEBUG=error,log \
+  ASPSP_AUTH_SERVER=http://localhost:8001 \
+  ASPSP_AUTH_SERVER_CLIENT_ID=spoofClientId \
+  ASPSP_AUTH_SERVER_CLIENT_SECRET=spoofClientSecret \
   ASPSP_READWRITE_HOST=localhost:8001 \
   OB_PROVISIONED=false \
   OB_DIRECTORY_HOST=http://localhost:8001 \
@@ -272,6 +275,9 @@ heroku create --region eu <newname>
 heroku addons:create redistogo # or any other redis add-on
 heroku addons:create mongolab:sandbox
 
+heroku config:set ASPSP_AUTH_SERVER=http://example-aspsp-auth-server.com
+heroku config:set ASPSP_AUTH_SERVER_CLIENT_ID=spoofClientId
+heroku config:set ASPSP_AUTH_SERVER_CLIENT_SECRET=spoofClientSecret
 heroku config:set ASPSP_READWRITE_HOST=example.com
 heroku config:set AUTHORIZATION=<mock-token>
 heroku config:set X_FAPI_FINANCIAL_ID=<mock-id>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpp-reference-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Reference TPP application API server",
   "author": "Open Banking Limited",
   "main": "index.js",


### PR DESCRIPTION
Based on major merges in the past 14 days on the REPO, this is a draft for the release notes.
```
TPP Reference Server (to read from Mock ASPSP and drive the Client App) written using Express on Node.js:

* Can request token for account request setup
* Added `/account-request-authorise-consent` endpoint for client app.
* Use clientId and clientSecret as credentials to access token endpoint
```

This PR includes:
* Updates to `README`.
* Release version bump.

These are the referenced commits:
* https://github.com/OpenBankingUK/tpp-reference-server/commit/e748162a2c9914fd2439957ba4151bbad46233b4
* https://github.com/OpenBankingUK/tpp-reference-server/commit/b26c531457e51e8e6c6dc141704b6752b4d79466