### PR TITLE
Fix version number in package-lock.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tpp-reference-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Small PR. The version number here needed to be bumped up to `0.3.0` to match `package.json`.