### PR TITLE
 Add listAuthServers script

### DIFF
--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -185,3 +185,4 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
 
 exports.OBAccountPaymentServiceProviders = OBAccountPaymentServiceProviders;
 exports.AUTH_SERVER_COLLECTION = AUTH_SERVER_COLLECTION;
+exports.allAuthorisationServers = allAuthorisationServers;

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -73,12 +73,22 @@ const storeAuthorisationServers = async (list) => {
   }));
 };
 
-const storedAuthorisationServers = async () => {
+const allAuthorisationServers = async () => {
   try {
     const list = await getAll(AUTH_SERVER_COLLECTION);
     if (!list) {
       return [];
     }
+    return list;
+  } catch (e) {
+    error(e);
+    return [];
+  }
+};
+
+const authorisationServersForClient = async () => {
+  try {
+    const list = await allAuthorisationServers();
     const servers = list.map(a => transformServerData(a.obDirectoryConfig));
     return sortByName(servers);
   } catch (e) {
@@ -153,7 +163,7 @@ const fetchOBAccountPaymentServiceProviders = async () => {
       const authServers = extractAuthorisationServers(response.data);
       debug(`data: ${JSON.stringify(authServers)}`);
       await storeAuthorisationServers(authServers);
-      return storedAuthorisationServers();
+      return authorisationServersForClient();
     }
     return [];
   } catch (e) {
@@ -164,7 +174,7 @@ const fetchOBAccountPaymentServiceProviders = async () => {
 
 const OBAccountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  let servers = storedAuthorisationServers();
+  let servers = authorisationServersForClient();
   if (servers.length > 0) {
     fetchOBAccountPaymentServiceProviders(); // async update store
   } else {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:watch": "NODE_ENV=test MONGODB_URI='localhost:27017/test-tpp-server' mocha --recursive --watch",
     "test:debug": "NODE_ENV=test MONGODB_URI='localhost:27017/test-tpp-server' node --inspect-brk node_modules/mocha/bin/_mocha --recursive --watch --no-timeouts",
     "eslint": "node ./node_modules/eslint/bin/eslint.js .",
-    "checks": "node ./node_modules/eslint/bin/eslint.js . && mocha"
+    "checks": "node ./node_modules/eslint/bin/eslint.js . && mocha",
+    "listAuthServers": "node ./scripts/list-auth-servers.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -1,0 +1,33 @@
+const { allAuthorisationServers } = require('../app/ob-directory');
+
+const authServerRows = async () => {
+  const header = [
+    'id',
+    'CustomerFriendlyName',
+    'orgId',
+    'clientCredentialsPresent',
+    'openIdConfigPresent',
+  ].join('\t');
+  const rows = [header];
+  const list = await allAuthorisationServers();
+  list.forEach((item) => {
+    const line = [
+      item.id,
+      item.obDirectoryConfig ? item.obDirectoryConfig.CustomerFriendlyName : '',
+      item.obDirectoryConfig ? item.obDirectoryConfig.orgId : '',
+      !!item.clientCredentials,
+      !!item.openIdConfig,
+    ].join('\t');
+    rows.push(line);
+  });
+  return rows;
+};
+
+authServerRows().then((rows) => {
+  rows.forEach(row => console.log(row));
+  if (process.env.NODE_ENV !== 'test') {
+    process.exit();
+  }
+});
+
+exports.authServerRows = authServerRows;

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -1,0 +1,60 @@
+const assert = require('assert'); // eslint-disable-line
+const proxyquire = require('proxyquire');// eslint-disable-line
+const sinon = require('sinon'); //eslint-disable-line
+
+const authorisationServersData = [
+  {
+    id: 'testId',
+    obDirectoryConfig: {
+      id: 'testId',
+      orgId: 'testOrdId',
+      CustomerFriendlyName: 'testName',
+    },
+    clientCredentials: { ex: 'ample' },
+    openIdConfig: { ex: 'ample' },
+  },
+  {
+    id: 'testId2',
+    obDirectoryConfig: {
+      id: 'testId2',
+      orgId: 'testOrdId',
+      CustomerFriendlyName: 'testName2',
+    },
+  },
+];
+
+describe('authServerRows', () => {
+  let authServerRows;
+
+  describe('when no auth servers present', () => {
+    beforeEach(() => {
+      authServerRows = require('../../scripts/list-auth-servers').authServerRows; // eslint-disable-line
+    });
+    it('returns tsv headers', async () => {
+      assert.deepEqual(
+        await authServerRows(),
+        ['id\tCustomerFriendlyName\torgId\tclientCredentialsPresent\topenIdConfigPresent'],
+      );
+    });
+  });
+
+  describe('when auth servers present', () => {
+    beforeEach(() => {
+      const authorisationServersStub = sinon.stub().returns(authorisationServersData);
+      authServerRows = proxyquire('../../scripts/list-auth-servers',   //eslint-disable-line
+        { '../app/ob-directory': { allAuthorisationServers: authorisationServersStub } },
+      ).authServerRows;
+    });
+
+    it('returns tsv of auth servers', async () => {
+      assert.deepEqual(
+        await authServerRows(),
+        [
+          'id\tCustomerFriendlyName\torgId\tclientCredentialsPresent\topenIdConfigPresent',
+          'testId\ttestName\ttestOrdId\ttrue\ttrue',
+          'testId2\ttestName2\ttestOrdId\tfalse\tfalse',
+        ],
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Add script that prints to console TSV list of auth servers.
- Outputs boolean flag for clientCredentialsPresent and openIdConfigPresent.
- For use to identify authorisation server id when configuring client credentials via another script.

Completes: REFAPP-79