### PR TITLE
Extract authorisation servers logic into separate file

### DIFF
--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -1,0 +1,70 @@
+// const log = require('debug')('log');
+const error = require('debug')('error');
+const { getAll, get, set } = require('../storage');
+
+const AUTH_SERVER_COLLECTION = 'aspspAuthorisationServers';
+
+const sortByName = (list) => {
+  list.sort((a, b) => {
+    if (a.name > b.name) {
+      return 1;
+    } else if (a.name > b.name) {
+      return -1;
+    }
+    return 0;
+  });
+  return list;
+};
+
+const transformServerData = (data) => {
+  const { id } = data;
+  const logoUri = data.CustomerFriendlyLogoUri;
+  const name = data.CustomerFriendlyName;
+  const { orgId } = data;
+  return {
+    id,
+    logoUri,
+    name,
+    orgId,
+  };
+};
+
+const storeAuthorisationServers = async (list) => {
+  await Promise.all(list.map(async (item) => {
+    const id = `${item.orgId}-${item.BaseApiDNSUri}`;
+    const existing = await get(AUTH_SERVER_COLLECTION, id);
+    const authServer = existing || {};
+    item.id = id; // eslint-disable-line
+    authServer.obDirectoryConfig = item;
+    await set(AUTH_SERVER_COLLECTION, authServer, id);
+  }));
+};
+
+const allAuthorisationServers = async () => {
+  try {
+    const list = await getAll(AUTH_SERVER_COLLECTION);
+    if (!list) {
+      return [];
+    }
+    return list;
+  } catch (e) {
+    error(e);
+    return [];
+  }
+};
+
+const authorisationServersForClient = async () => {
+  try {
+    const list = await allAuthorisationServers();
+    const servers = list.map(a => transformServerData(a.obDirectoryConfig));
+    return sortByName(servers);
+  } catch (e) {
+    error(e);
+    return [];
+  }
+};
+
+exports.storeAuthorisationServers = storeAuthorisationServers;
+exports.allAuthorisationServers = allAuthorisationServers;
+exports.authorisationServersForClient = authorisationServersForClient;
+exports.AUTH_SERVER_COLLECTION = AUTH_SERVER_COLLECTION;

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -1,0 +1,9 @@
+const {
+  allAuthorisationServers,
+  authorisationServersForClient,
+  storeAuthorisationServers,
+} = require('./authorisation-servers');
+
+exports.allAuthorisationServers = allAuthorisationServers;
+exports.authorisationServersForClient = authorisationServersForClient;
+exports.storeAuthorisationServers = storeAuthorisationServers;

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -7,9 +7,11 @@ const util = require('util');
 const debug = require('debug')('debug');
 const log = require('debug')('log');
 const error = require('debug')('error');
-const { getAll, get, set } = require('./storage');
+const {
+  authorisationServersForClient,
+  storeAuthorisationServers,
+} = require('./authorisation-servers');
 
-const AUTH_SERVER_COLLECTION = 'aspspAuthorisationServers';
 const NOT_PROVISIONED_FOR_OB_TOKEN = 'NO_TOKEN';
 
 const provisionedForOpenBanking = process.env.OB_PROVISIONED === 'true';
@@ -24,31 +26,6 @@ log(`OB_DIRECTORY_HOST: ${directoryHost}`);
 
 const getSessionAccessToken = util.promisify(session.getAccessToken);
 
-const sortByName = (list) => {
-  list.sort((a, b) => {
-    if (a.name > b.name) {
-      return 1;
-    } else if (a.name > b.name) {
-      return -1;
-    }
-    return 0;
-  });
-  return list;
-};
-
-const transformServerData = (data) => {
-  const { id } = data;
-  const logoUri = data.CustomerFriendlyLogoUri;
-  const name = data.CustomerFriendlyName;
-  const { orgId } = data;
-  return {
-    id,
-    logoUri,
-    name,
-    orgId,
-  };
-};
-
 const extractAuthorisationServers = (data) => {
   if (!data.Resources) {
     return [];
@@ -61,41 +38,6 @@ const extractAuthorisationServers = (data) => {
     }))
     .reduce((a, b) => a.concat(b), []); // flatten array
   return authServers;
-};
-
-const storeAuthorisationServers = async (list) => {
-  await Promise.all(list.map(async (item) => {
-    const id = `${item.orgId}-${item.BaseApiDNSUri}`;
-    const existing = await get(AUTH_SERVER_COLLECTION, id);
-    const authServer = existing || {};
-    item.id = id; // eslint-disable-line
-    authServer.obDirectoryConfig = item;
-    await set(AUTH_SERVER_COLLECTION, authServer, id);
-  }));
-};
-
-const allAuthorisationServers = async () => {
-  try {
-    const list = await getAll(AUTH_SERVER_COLLECTION);
-    if (!list) {
-      return [];
-    }
-    return list;
-  } catch (e) {
-    error(e);
-    return [];
-  }
-};
-
-const authorisationServersForClient = async () => {
-  try {
-    const list = await allAuthorisationServers();
-    const servers = list.map(a => transformServerData(a.obDirectoryConfig));
-    return sortByName(servers);
-  } catch (e) {
-    error(e);
-    return [];
-  }
 };
 
 const getAccessToken = async () => {
@@ -178,5 +120,3 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
 };
 
 exports.OBAccountPaymentServiceProviders = OBAccountPaymentServiceProviders;
-exports.AUTH_SERVER_COLLECTION = AUTH_SERVER_COLLECTION;
-exports.allAuthorisationServers = allAuthorisationServers;

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -1,4 +1,4 @@
-const { allAuthorisationServers } = require('../app/ob-directory');
+const { allAuthorisationServers } = require('../app/authorisation-servers');
 
 const authServerRows = async () => {
   const header = [

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert'); // eslint-disable-line
-const proxyquire = require('proxyquire');// eslint-disable-line
+const proxyquire = require('proxyquire'); // eslint-disable-line
 const sinon = require('sinon'); //eslint-disable-line
 
 const authorisationServersData = [
@@ -22,14 +22,21 @@ const authorisationServersData = [
     },
   },
 ];
+let authServerRows;
+
+const authServerRowsFn = (authServerList) => {
+  const allAuthorisationServersStub = sinon.stub().returns(authServerList);
+  return proxyquire('../../scripts/list-auth-servers', // eslint-disable-line
+    { '../app/authorisation-servers': { allAuthorisationServers: allAuthorisationServersStub } },
+  ).authServerRows;
+};
 
 describe('authServerRows', () => {
-  let authServerRows;
-
   describe('when no auth servers present', () => {
     beforeEach(() => {
-      authServerRows = require('../../scripts/list-auth-servers').authServerRows; // eslint-disable-line
+      authServerRows = authServerRowsFn([]);
     });
+
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
@@ -40,10 +47,7 @@ describe('authServerRows', () => {
 
   describe('when auth servers present', () => {
     beforeEach(() => {
-      const authorisationServersStub = sinon.stub().returns(authorisationServersData);
-      authServerRows = proxyquire('../../scripts/list-auth-servers',   //eslint-disable-line
-        { '../app/ob-directory': { allAuthorisationServers: authorisationServersStub } },
-      ).authServerRows;
+      authServerRows = authServerRowsFn(authorisationServersData);
     });
 
     it('returns tsv of auth servers', async () => {


### PR DESCRIPTION
- Extract auth server code from ob-directory into new file.
- Update references to moved functions.
- Refactor list auth server test to put stubbing in a function.

A refactoring, in preparation for storing openid config in a later PR.