### PR TITLE
Fetch and store openId configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,3 +362,26 @@ The server has to be configured with
 * `OB_ISSUING_CA=<base64 encoded cert>` (CA) - Downloaded / base64 encoded `OB Issuing CA` cert from OB Directory.
 * `TRANSPORT_CERT=<base64 encoded cert>` (CERT) - Downloaded / base64 encoded `Transport` cert from OB Directory console.
 * `TRANSPORT_KEY=<base64 encoded private key>` (KEY) - private key used to generate `Transport` cert CSR.
+
+### Configuration of ASPSP Authorisation Servers
+
+When the `/account-payment-service-provider-authorisation-servers` endpoint is
+called on the server, a list of ASPSP authorisation servers is fetched from
+OB Directory and stored in the server's database.
+
+For each authorisation server the OpenId config is fetched and stored in the
+database.
+
+To list authorisation servers currently in the database, run:
+
+```sh
+npm run listAuthServers --silent
+```
+
+Output on terminal is TSV that looks like this:
+```
+id	CustomerFriendlyName	orgId	clientCredentialsPresent	openIdConfigPresent
+aaa-example-bank-http://aaa-example-bank.example.com	AAA Example Bank	aaa-example-bank	false	true
+ccc-example-bank-http://ccc-example-bank.example.com	CCC Example Bank	ccc-example-bank	false	false
+bbb-example-bank-http://bbb-example-bank.example.com	BBB Example Bank	bbb-example-bank	false	false
+```

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -2,8 +2,10 @@ const {
   allAuthorisationServers,
   authorisationServersForClient,
   storeAuthorisationServers,
+  updateOpenIdConfigs,
 } = require('./authorisation-servers');
 
 exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
 exports.storeAuthorisationServers = storeAuthorisationServers;
+exports.updateOpenIdConfigs = updateOpenIdConfigs;

--- a/app/authorisation-servers/openid-config.js
+++ b/app/authorisation-servers/openid-config.js
@@ -1,0 +1,14 @@
+const request = require('superagent');
+const log = require('debug')('log');
+const { setupMutualTLS } = require('../certs-util');
+
+const getOpenIdConfig = async (url) => {
+  log(`GET ${url}`);
+  const response = await setupMutualTLS(request)
+    .get(url)
+    .set('accept', 'application/json; charset=utf-8')
+    .send();
+  return response.body;
+};
+
+exports.getOpenIdConfig = getOpenIdConfig;

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -10,6 +10,7 @@ const error = require('debug')('error');
 const {
   authorisationServersForClient,
   storeAuthorisationServers,
+  updateOpenIdConfigs,
 } = require('./authorisation-servers');
 
 const NOT_PROVISIONED_FOR_OB_TOKEN = 'NO_TOKEN';
@@ -112,7 +113,8 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   let servers = authorisationServersForClient();
   if (servers.length > 0) {
-    fetchOBAccountPaymentServiceProviders(); // async update store
+    fetchOBAccountPaymentServiceProviders() // async update store
+      .then(() => updateOpenIdConfigs()); // async update openId configs
   } else {
     servers = await fetchOBAccountPaymentServiceProviders();
   }

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -113,10 +113,11 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   let servers = authorisationServersForClient();
   if (servers.length > 0) {
-    fetchOBAccountPaymentServiceProviders() // async update store
+    fetchOBAccountPaymentServiceProviders() // async update auth servers
       .then(() => updateOpenIdConfigs()); // async update openId configs
   } else {
-    servers = await fetchOBAccountPaymentServiceProviders();
+    servers = await fetchOBAccountPaymentServiceProviders(); // fetch auth servers
+    await updateOpenIdConfigs(); // fetch openid configs
   }
   return res.json(servers);
 };

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -24,8 +24,8 @@ const authServerRows = async () => {
 };
 
 authServerRows().then((rows) => {
-  rows.forEach(row => console.log(row));
   if (process.env.NODE_ENV !== 'test') {
+    rows.forEach(row => console.log(row)); // eslint-disable-line
     process.exit();
   }
 });

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const { drop } = require('../../app/storage.js');
+const { AUTH_SERVER_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
+const {
+  allAuthorisationServers,
+  storeAuthorisationServers,
+  updateOpenIdConfigs,
+} = require('../../app/authorisation-servers');
+
+const nock = require('nock');
+
+const flattenedObDirectoryAuthServerList = [
+  {
+    BaseApiDNSUri: 'http://aaa.example.com',
+    CustomerFriendlyName: 'AAA Example Bank',
+    OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
+    orgId: 'aaa-example-org',
+  },
+];
+
+const openIdConfig = {
+  authorization_endpoint: 'http://auth.example.com/authorize',
+  token_endpoint: 'http://auth.example.com/token',
+};
+
+const expectedAuthServerConfig = {
+  id: 'aaa-example-org-http://aaa.example.com',
+  obDirectoryConfig: {
+    BaseApiDNSUri: 'http://aaa.example.com',
+    CustomerFriendlyName: 'AAA Example Bank',
+    OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
+    id: 'aaa-example-org-http://aaa.example.com',
+    orgId: 'aaa-example-org',
+  },
+  openIdConfig: {
+    authorization_endpoint: 'http://auth.example.com/authorize',
+    token_endpoint: 'http://auth.example.com/token',
+  },
+};
+
+nock(/example\.com/)
+  .get('/openidconfig')
+  .reply(200, openIdConfig);
+
+describe('updateOpenIdConfigs', () => {
+  beforeEach(async () => {
+    await drop(AUTH_SERVER_COLLECTION);
+    await storeAuthorisationServers(flattenedObDirectoryAuthServerList);
+  });
+
+  afterEach(async () => {
+    await drop(AUTH_SERVER_COLLECTION);
+  });
+
+  it('before called openIdConfig not present', async () => {
+    const list = await allAuthorisationServers();
+    const authServerConfig = list[0];
+    assert.ok(!authServerConfig.openIdConfig, 'openIdConfig not present');
+  });
+
+  it('retrieves openIdConfig and stores in db', async () => {
+    await updateOpenIdConfigs();
+    const list = await allAuthorisationServers();
+    const authServerConfig = list[0];
+    assert.ok(authServerConfig.openIdConfig, 'openIdConfig present');
+    assert.deepEqual(authServerConfig, expectedAuthServerConfig);
+  });
+});

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -8,7 +8,7 @@ const { drop } = require('../app/storage.js');
 
 const { app } = require('../app/index.js');
 const { session } = require('../app/session.js');
-const { AUTH_SERVER_COLLECTION } = require('../app/ob-directory');
+const { AUTH_SERVER_COLLECTION } = require('../app/authorisation-servers/authorisation-servers');
 
 const assert = require('assert');
 const nock = require('nock');
@@ -93,15 +93,18 @@ const login = application => request(application)
   .send({ u: 'alice', p: 'wonderland' });
 
 describe('Directory', () => {
-  before(() => {
+  beforeEach(async () => {
+    await drop(AUTH_SERVER_COLLECTION);
+    session.setId('foo');
     // set up dummy but valid signing_key to sign jwt
     process.env.SIGNING_KEY = 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQ0KTUlJQk9RSUJBQUpCQU1Odng4ZmtUNmJXYk1jNGNqdTc1eC9kdkZvYnBIWjNVU25lbWhCNUxYQVFYb2c0eTVqVA0KaXdvOTVBdWJONDB1Mm1YRDhRVWhCNFJFQ2Q0alAvWmczMlVDQXdFQUFRSkFXRzE2VW9xT002bnZuQkNCTjEvaw0KeXJsVVlOMERCQXNtc1RBa08zSG95andDMVpKUG9COUQ4SGJEYzljWnhjRW5vQTZDK2pvNmxSN2NOWTlDRWthbQ0KZ1FJaEFQR2I1S2UxVEQreTBleW1Sb21KVEk5VzZjdmNmVk85dWlhZnVjbjBvLzNGQWlFQXp4UFhicHIxZGtBeg0KZG45QVlMazFIZU1vaXZqak0zVVpFUGhkNmJaOEZTRUNJRngzcDJrd0Q4Q0pOYUoyZUtTR3NaQmlXUlEyakppUw0KRWo1Wi93YjE1QlZwQWlCdHVoN1N2Z3ZKY0RXVTJkTWNMYWVtd2FMUEdSa1RRRDViRHJCODBqU240UUlnY243cw0KYTRvcFdtMVhLM3V3WGhBcXVqY3FnY1NseEpZQXMwWGtvSUNOV3c0PQ0KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0=';
   });
 
-  after(() => {
+  afterEach(async () => {
     delete process.env.SIGNING_KEY;
+    session.deleteAll();
+    await drop(AUTH_SERVER_COLLECTION);
   });
-  session.setId('foo');
 
   it('returns proxy 200 response for /account-payment-service-provider-authorisation-servers', (done) => {
     login(app).end((err, res) => {
@@ -122,10 +125,5 @@ describe('Directory', () => {
           done();
         });
     });
-  });
-
-  after(() => {
-    drop(AUTH_SERVER_COLLECTION);
-    session.deleteAll();
   });
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -45,7 +45,7 @@ describe('storage set data with id', () => {
     return assert.deepEqual(expected, result);
   });
 
-  after(() => {
-    drop(collection);
+  after(async () => {
+    await drop(collection);
   });
 });


### PR DESCRIPTION
- Add updateOpenIdConfigs() function to fetch and store configs.
- Fetch and store openIdConfig for each authorisation server without openIdConfig.
- Trigger async update of openIdConfigs when client requests ASPSP list (for now this seems a good time to fetch them)
- Await db cleanup to finish in test setups and teardowns

For: REFAPP-45