### PR TITLE
Use authorisation server Ids and other data from OB Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,28 +81,25 @@ curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' http://loca
 
 Here's a sample list of test ASPSPs. This is __NOT__ the raw response from the Open Banking Directory. It has been adapted to simulate what a typical client app would require.
 
-> __NOTE__: the actual `id` won't be a URI. It'll be an authorisation server id - that is planned to be added to the Directory JSON payload.
-> We are simulating an `id` by combining the ASPSP's `organisation id` with the authorisation server `BaseApiDNSUri`.
-
 ```sh
 [
   {
-    "id": "aaa-example-org-http://aaa.example.com",
+    "id": "aaaj4NmBD8lQxmL",
     "logoUri": "",
     "name": "AAA Example Bank",
-    "orgId": "aaa-example-org",
+    "orgId": "aaax5nTR33811QyQfi",
   },
   {
-    "id": "bbbccc-example-org-http://bbb.example.com",
+    "id": "bbbX7tUB4fPIYB0",
     "logoUri": "",
     "name": "BBB Example Bank",
-    "orgId": "bbbccc-example-org",
+    "orgId": "bbbUB4fPIYB0k1m",
   },
   {
-    "id": "bbbccc-example-org-http://ccc.example.com",
+    "id": "cccbN8iAsMh74sO",
     "logoUri": "",
     "name": "CCC Example Bank",
-    "orgId": "bbbccc-example-org",
+    "orgId": "cccMh74sOXhk",
   }
 ]
 ```
@@ -111,10 +108,10 @@ Here's a sample list of test ASPSPs. This is __NOT__ the raw response from the O
 
 There is a script to input and store client credentials against ASPSP Auth Server Records
 
-Example Usages 
+Example Usages
 
 ```
-# Locally 
+# Locally
 npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
 
 # Remotely
@@ -395,8 +392,8 @@ npm run listAuthServers --silent
 
 Output on terminal is TSV that looks like this:
 ```
-id	CustomerFriendlyName	orgId	clientCredentialsPresent	openIdConfigPresent
-aaa-example-bank-http://aaa-example-bank.example.com	AAA Example Bank	aaa-example-bank	false	true
-ccc-example-bank-http://ccc-example-bank.example.com	CCC Example Bank	ccc-example-bank	false	false
-bbb-example-bank-http://bbb-example-bank.example.com	BBB Example Bank	bbb-example-bank	false	false
+id               CustomerFriendlyName OrganisationCommonName Authority  OBOrganisationId   clientCredentialsPresent openIdConfigPresent
+aaaj4NmBD8lQxmL  AAA Example Bank     AAA Example PLC        GB:FCA:123 aaax5nTR33811QyQfi false                    false
+bbbX7tUB4fPIYB0  BBB Example Bank     BBB Example PLC        GB:FCA:456 bbbUB4fPIYB0k1m    false                    false
+cccbN8iAsMh74sO  CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh74sOXhk       false                    false
 ```

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -2,7 +2,7 @@ const error = require('debug')('error');
 const { getAll, get, set } = require('../storage');
 const { getOpenIdConfig } = require('./openid-config');
 
-const AUTH_SERVER_COLLECTION = 'aspspAuthorisationServers';
+const ASPSP_AUTH_SERVERS_COLLECTION = 'aspspAuthorisationServers';
 
 const sortByName = (list) => {
   list.sort((a, b) => {
@@ -29,9 +29,9 @@ const transformServerData = (data) => {
   };
 };
 
-const getAuthServerConfig = async id => get(AUTH_SERVER_COLLECTION, id);
+const getAuthServerConfig = async id => get(ASPSP_AUTH_SERVERS_COLLECTION, id);
 
-const setAuthServerConfig = async (id, authServer) => set(AUTH_SERVER_COLLECTION, authServer, id);
+const setAuthServerConfig = async (id, authServer) => set(ASPSP_AUTH_SERVERS_COLLECTION, authServer, id);
 
 const storeAuthorisationServers = async (list) => {
   await Promise.all(list.map(async (item) => {
@@ -46,7 +46,7 @@ const storeAuthorisationServers = async (list) => {
 
 const allAuthorisationServers = async () => {
   try {
-    const list = await getAll(AUTH_SERVER_COLLECTION);
+    const list = await getAll(ASPSP_AUTH_SERVERS_COLLECTION);
     if (!list) {
       return [];
     }
@@ -108,4 +108,4 @@ exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
 exports.updateOpenIdConfigs = updateOpenIdConfigs;
 exports.updateClientCredentials = updateClientCredentials;
-exports.AUTH_SERVER_COLLECTION = AUTH_SERVER_COLLECTION;
+exports.ASPSP_AUTH_SERVERS_COLLECTION = ASPSP_AUTH_SERVERS_COLLECTION;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -20,7 +20,7 @@ const transformServerData = (data) => {
   const id = data.Id;
   const logoUri = data.CustomerFriendlyLogoUri;
   const name = data.CustomerFriendlyName;
-  const { orgId } = data;
+  const orgId = data.OBOrganisationId;
   return {
     id,
     logoUri,

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -17,7 +17,7 @@ const sortByName = (list) => {
 };
 
 const transformServerData = (data) => {
-  const { id } = data;
+  const id = data.Id;
   const logoUri = data.CustomerFriendlyLogoUri;
   const name = data.CustomerFriendlyName;
   const { orgId } = data;
@@ -31,14 +31,14 @@ const transformServerData = (data) => {
 
 const getAuthServerConfig = async id => get(ASPSP_AUTH_SERVERS_COLLECTION, id);
 
-const setAuthServerConfig = async (id, authServer) => set(ASPSP_AUTH_SERVERS_COLLECTION, authServer, id);
+const setAuthServerConfig = async (id, authServer) =>
+  set(ASPSP_AUTH_SERVERS_COLLECTION, authServer, id);
 
 const storeAuthorisationServers = async (list) => {
   await Promise.all(list.map(async (item) => {
-    const id = `${item.orgId}-${item.BaseApiDNSUri}`;
+    const id = item.Id;
     const existing = await getAuthServerConfig(id);
     const authServer = existing || {};
-    item.id = id; // eslint-disable-line
     authServer.obDirectoryConfig = item;
     await setAuthServerConfig(id, authServer);
   }));

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -37,6 +37,10 @@ const extractAuthorisationServers = (data) => {
       const organisation = resource['urn:openbanking:organisation:1.0'];
       r.OBOrganisationId = organisation ? organisation.OBOrganisationId : ''; // eslint-disable-line
       r.OrganisationCommonName = organisation ? organisation.OrganisationCommonName : ''; // eslint-disable-line
+      const authority = resource['urn:openbanking:competentauthorityclaims:1.0'];
+      r.AuthorityId = authority ? authority.AuthorityId : ''; // eslint-disable-line
+      r.MemberState = authority ? authority.MemberState : ''; // eslint-disable-line
+      r.RegistrationId = authority ? authority.RegistrationId : ''; // eslint-disable-line
       return r;
     }))
     .reduce((a, b) => a.concat(b), []); // flatten array

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -113,7 +113,8 @@ const fetchOBAccountPaymentServiceProviders = async () => {
 
 const OBAccountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  let servers = authorisationServersForClient();
+  let servers = await authorisationServersForClient();
+  log(`servers length: ${servers.length}`);
   if (servers.length > 0) {
     fetchOBAccountPaymentServiceProviders() // async update auth servers
       .then(() => updateOpenIdConfigs()); // async update openId configs

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -34,7 +34,9 @@ const extractAuthorisationServers = (data) => {
   const authServers = data.Resources
     .filter(resource => !!resource.AuthorisationServers)
     .map(resource => resource.AuthorisationServers.map((r) => {
-      r.orgId = resource.id; // eslint-disable-line
+      const organisation = resource['urn:openbanking:organisation:1.0'];
+      r.OBOrganisationId = organisation ? organisation.OBOrganisationId : ''; // eslint-disable-line
+      r.OrganisationCommonName = organisation ? organisation.OrganisationCommonName : ''; // eslint-disable-line
       return r;
     }))
     .reduce((a, b) => a.concat(b), []); // flatten array
@@ -98,7 +100,7 @@ const fetchOBAccountPaymentServiceProviders = async () => {
     log(`response: ${response.status}`);
     if (response.status === 200) {
       const authServers = extractAuthorisationServers(response.body);
-      debug(`data: ${JSON.stringify(authServers)}`);
+      debug(`authServers: ${JSON.stringify(authServers)}`);
       await storeAuthorisationServers(authServers);
       return authorisationServersForClient();
     }
@@ -122,4 +124,5 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
   return res.json(servers);
 };
 
+exports.extractAuthorisationServers = extractAuthorisationServers;
 exports.OBAccountPaymentServiceProviders = OBAccountPaymentServiceProviders;

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -4,7 +4,7 @@ const authServerRows = async () => {
   const header = [
     'id',
     'CustomerFriendlyName',
-    'orgId',
+    'OBOrganisationId',
     'clientCredentialsPresent',
     'openIdConfigPresent',
   ].join('\t');
@@ -14,7 +14,7 @@ const authServerRows = async () => {
     const line = [
       item.id,
       item.obDirectoryConfig ? item.obDirectoryConfig.CustomerFriendlyName : '',
-      item.obDirectoryConfig ? item.obDirectoryConfig.orgId : '',
+      item.obDirectoryConfig ? item.obDirectoryConfig.OBOrganisationId : '',
       !!item.clientCredentials,
       !!item.openIdConfig,
     ].join('\t');

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -4,6 +4,7 @@ const authServerRows = async () => {
   const header = [
     'id',
     'CustomerFriendlyName',
+    'OrganisationCommonName',
     'OBOrganisationId',
     'clientCredentialsPresent',
     'openIdConfigPresent',
@@ -11,10 +12,12 @@ const authServerRows = async () => {
   const rows = [header];
   const list = await allAuthorisationServers();
   list.forEach((item) => {
+    const config = item.obDirectoryConfig;
     const line = [
       item.id,
-      item.obDirectoryConfig ? item.obDirectoryConfig.CustomerFriendlyName : '',
-      item.obDirectoryConfig ? item.obDirectoryConfig.OBOrganisationId : '',
+      config ? config.CustomerFriendlyName : '',
+      config ? config.OrganisationCommonName : '',
+      config ? config.OBOrganisationId : '',
       !!item.clientCredentials,
       !!item.openIdConfig,
     ].join('\t');

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -5,6 +5,7 @@ const authServerRows = async () => {
     'id',
     'CustomerFriendlyName',
     'OrganisationCommonName',
+    'Authority',
     'OBOrganisationId',
     'clientCredentialsPresent',
     'openIdConfigPresent',
@@ -13,10 +14,13 @@ const authServerRows = async () => {
   const list = await allAuthorisationServers();
   list.forEach((item) => {
     const config = item.obDirectoryConfig;
+    const authorityPresent = config && config.AuthorityId
+      && config.MemberState && config.RegistrationId;
     const line = [
       item.id,
       config ? config.CustomerFriendlyName : '',
       config ? config.OrganisationCommonName : '',
+      authorityPresent ? `${config.MemberState}:${config.AuthorityId}:${config.RegistrationId}` : '',
       config ? config.OBOrganisationId : '',
       !!item.clientCredentials,
       !!item.openIdConfig,

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { drop } = require('../../app/storage.js');
-const { AUTH_SERVER_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
+const { ASPSP_AUTH_SERVERS_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
 const {
   allAuthorisationServers,
   storeAuthorisationServers,
@@ -61,12 +61,12 @@ nock(/example\.com/)
 
 describe('updateOpenIdConfigs', () => {
   beforeEach(async () => {
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
     await storeAuthorisationServers(flattenedObDirectoryAuthServerList);
   });
 
   afterEach(async () => {
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
   });
 
   it('before called openIdConfig not present', async () => {
@@ -86,12 +86,12 @@ describe('updateOpenIdConfigs', () => {
 
 describe('updateClientCredentials', () => {
   beforeEach(async () => {
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
     await storeAuthorisationServers(flattenedObDirectoryAuthServerList);
   });
 
   afterEach(async () => {
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
   });
 
   it('before called clientCredentials not present', async () => {

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -10,13 +10,14 @@ const {
 
 const nock = require('nock');
 
+const authServerId = 'aaaj4NmBD8lQxmLh2O9FLY';
 const flattenedObDirectoryAuthServerList = [
   {
-    Id: 'aaaj4NmBD8lQxmLh2O9FLY',
+    Id: authServerId,
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
-    orgId: 'aaa-example-org',
+    OBOrganisationId: 'aaa-example-org',
   },
 ];
 
@@ -26,13 +27,13 @@ const openIdConfig = {
 };
 
 const expectedAuthServerConfig = {
-  id: 'aaaj4NmBD8lQxmLh2O9FLY',
+  id: authServerId,
   obDirectoryConfig: {
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
-    Id: 'aaaj4NmBD8lQxmLh2O9FLY',
-    orgId: 'aaa-example-org',
+    Id: authServerId,
+    OBOrganisationId: 'aaa-example-org',
   },
   openIdConfig: {
     authorization_endpoint: 'http://auth.example.com/authorize',
@@ -41,13 +42,13 @@ const expectedAuthServerConfig = {
 };
 
 const expectedClientCredentials = {
-  id: 'aaa-example-org-http://aaa.example.com',
+  id: authServerId,
   obDirectoryConfig: {
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
-    id: 'aaa-example-org-http://aaa.example.com',
-    orgId: 'aaa-example-org',
+    Id: authServerId,
+    OBOrganisationId: 'aaa-example-org',
   },
   clientCredentials: {
     clientId: 'abc',
@@ -102,7 +103,7 @@ describe('updateClientCredentials', () => {
   });
 
   it('stores clientCredential in db', async () => {
-    await updateClientCredentials('aaa-example-org-http://aaa.example.com', { clientId: 'abc', clientSecret: 'xyz' });
+    await updateClientCredentials(authServerId, { clientId: 'abc', clientSecret: 'xyz' });
     const list = await allAuthorisationServers();
     const authServerConfig = list[0];
     assert.ok(authServerConfig.clientCredentials, 'clientCredentials present');

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -12,6 +12,7 @@ const nock = require('nock');
 
 const flattenedObDirectoryAuthServerList = [
   {
+    Id: 'aaaj4NmBD8lQxmLh2O9FLY',
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
@@ -25,12 +26,12 @@ const openIdConfig = {
 };
 
 const expectedAuthServerConfig = {
-  id: 'aaa-example-org-http://aaa.example.com',
+  id: 'aaaj4NmBD8lQxmLh2O9FLY',
   obDirectoryConfig: {
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
-    id: 'aaa-example-org-http://aaa.example.com',
+    Id: 'aaaj4NmBD8lQxmLh2O9FLY',
     orgId: 'aaa-example-org',
   },
   openIdConfig: {

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -57,6 +57,11 @@ const expectedResult = [
 const aspspPayload = {
   Resources: [
     {
+      'urn:openbanking:competentauthorityclaims:1.0': {
+        AuthorityId: 'FCA',
+        MemberState: 'GB',
+        RegistrationId: '123',
+      },
       'AuthorisationServers': [
         {
           Id: 'aaaj4NmBD8lQxmLh2O9FLY',
@@ -73,6 +78,11 @@ const aspspPayload = {
       'id': 'aaax5nTR33811QyQfi',
     },
     {
+      'urn:openbanking:competentauthorityclaims:1.0': {
+        AuthorityId: 'FCA',
+        MemberState: 'GB',
+        RegistrationId: '456',
+      },
       'AuthorisationServers': [
         {
           Id: 'bbbX7tUB4fPIYB0k1m',
@@ -113,6 +123,9 @@ describe('extractAuthorisationServers', () => {
         OpenIDConfigEndPointUri: 'http://aaa.example.com/openid/config',
         OBOrganisationId: 'aaax5nTR33811QyQfi',
         OrganisationCommonName: 'AAA Group PLC',
+        AuthorityId: 'FCA',
+        MemberState: 'GB',
+        RegistrationId: '123',
       },
       {
         BaseApiDNSUri: 'http://bbb.example.com',
@@ -122,6 +135,9 @@ describe('extractAuthorisationServers', () => {
         OpenIDConfigEndPointUri: 'http://bbb.example.com/openid/config',
         OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
         OrganisationCommonName: 'BBBCCC Group PLC',
+        AuthorityId: 'FCA',
+        MemberState: 'GB',
+        RegistrationId: '456',
       },
       {
         BaseApiDNSUri: 'http://ccc.example.com',
@@ -131,6 +147,9 @@ describe('extractAuthorisationServers', () => {
         OpenIDConfigEndPointUri: 'http://ccc.example.com/openid/config',
         OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
         OrganisationCommonName: 'BBBCCC Group PLC',
+        AuthorityId: 'FCA',
+        MemberState: 'GB',
+        RegistrationId: '456',
       },
     ];
     assert.deepEqual(list, expected);

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -2,6 +2,8 @@ const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
 
+const { extractAuthorisationServers } = require('../app/ob-directory');
+
 const accessToken = 'AN_ACCESS_TOKEN';
 
 const { drop } = require('../app/storage.js');
@@ -98,6 +100,42 @@ const aspspPayload = {
     },
   ],
 };
+
+describe('extractAuthorisationServers', () => {
+  it('returns flattened ASPSP auth server list', () => {
+    const list = extractAuthorisationServers(aspspPayload);
+    const expected = [
+      {
+        BaseApiDNSUri: 'http://aaa.example.com',
+        CustomerFriendlyLogoUri: 'string',
+        CustomerFriendlyName: 'AAA Example Bank',
+        Id: 'aaaj4NmBD8lQxmLh2O9FLY',
+        OpenIDConfigEndPointUri: 'http://aaa.example.com/openid/config',
+        OBOrganisationId: 'aaax5nTR33811QyQfi',
+        OrganisationCommonName: 'AAA Group PLC',
+      },
+      {
+        BaseApiDNSUri: 'http://bbb.example.com',
+        CustomerFriendlyLogoUri: 'string',
+        CustomerFriendlyName: 'BBB Example Bank',
+        Id: 'bbbX7tUB4fPIYB0k1m',
+        OpenIDConfigEndPointUri: 'http://bbb.example.com/openid/config',
+        OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
+        OrganisationCommonName: 'BBBCCC Group PLC',
+      },
+      {
+        BaseApiDNSUri: 'http://ccc.example.com',
+        CustomerFriendlyLogoUri: 'string',
+        CustomerFriendlyName: 'CCC Example Bank',
+        Id: 'cccbN8iAsMh74sOXhk',
+        OpenIDConfigEndPointUri: 'http://ccc.example.com/openid/config',
+        OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
+        OrganisationCommonName: 'BBBCCC Group PLC',
+      },
+    ];
+    assert.deepEqual(list, expected);
+  });
+});
 
 nock(/example\.com/, directoryHeaders)
   .get('/scim/v2/OBAccountPaymentServiceProviders/')

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -8,7 +8,7 @@ const { drop } = require('../app/storage.js');
 
 const { app } = require('../app/index.js');
 const { session } = require('../app/session.js');
-const { AUTH_SERVER_COLLECTION } = require('../app/authorisation-servers/authorisation-servers');
+const { ASPSP_AUTH_SERVERS_COLLECTION } = require('../app/authorisation-servers/authorisation-servers');
 
 const assert = require('assert');
 const nock = require('nock');
@@ -94,7 +94,7 @@ const login = application => request(application)
 
 describe('Directory', () => {
   beforeEach(async () => {
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
     session.setId('foo');
     // set up dummy but valid signing_key to sign jwt
     process.env.SIGNING_KEY = 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQ0KTUlJQk9RSUJBQUpCQU1Odng4ZmtUNmJXYk1jNGNqdTc1eC9kdkZvYnBIWjNVU25lbWhCNUxYQVFYb2c0eTVqVA0KaXdvOTVBdWJONDB1Mm1YRDhRVWhCNFJFQ2Q0alAvWmczMlVDQXdFQUFRSkFXRzE2VW9xT002bnZuQkNCTjEvaw0KeXJsVVlOMERCQXNtc1RBa08zSG95andDMVpKUG9COUQ4SGJEYzljWnhjRW5vQTZDK2pvNmxSN2NOWTlDRWthbQ0KZ1FJaEFQR2I1S2UxVEQreTBleW1Sb21KVEk5VzZjdmNmVk85dWlhZnVjbjBvLzNGQWlFQXp4UFhicHIxZGtBeg0KZG45QVlMazFIZU1vaXZqak0zVVpFUGhkNmJaOEZTRUNJRngzcDJrd0Q4Q0pOYUoyZUtTR3NaQmlXUlEyakppUw0KRWo1Wi93YjE1QlZwQWlCdHVoN1N2Z3ZKY0RXVTJkTWNMYWVtd2FMUEdSa1RRRDViRHJCODBqU240UUlnY243cw0KYTRvcFdtMVhLM3V3WGhBcXVqY3FnY1NseEpZQXMwWGtvSUNOV3c0PQ0KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0=';
@@ -103,7 +103,7 @@ describe('Directory', () => {
   afterEach(async () => {
     delete process.env.SIGNING_KEY;
     session.deleteAll();
-    await drop(AUTH_SERVER_COLLECTION);
+    await drop(ASPSP_AUTH_SERVERS_COLLECTION);
   });
 
   it('returns proxy 200 response for /account-payment-service-provider-authorisation-servers', (done) => {

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -33,22 +33,22 @@ const directoryHeaders = {
 
 const expectedResult = [
   {
-    id: 'aaa-example-org-http://aaa.example.com',
+    id: 'aaaj4NmBD8lQxmLh2O9FLY',
     logoUri: 'string',
     name: 'AAA Example Bank',
-    orgId: 'aaa-example-org',
+    orgId: 'aaax5nTR33811QyQfi',
   },
   {
-    id: 'bbbccc-example-org-http://bbb.example.com',
+    id: 'bbbj4NmBD8lQxmLh2O9FLY',
     logoUri: 'string',
     name: 'BBB Example Bank',
-    orgId: 'bbbccc-example-org',
+    orgId: 'bbbcccUB4fPIYB0k1m',
   },
   {
-    id: 'bbbccc-example-org-http://ccc.example.com',
+    id: 'cccj4NmBD8lQxmLh2O9FLY',
     logoUri: 'string',
     name: 'CCC Example Bank',
-    orgId: 'bbbccc-example-org',
+    orgId: 'bbbcccUB4fPIYB0k1m',
   },
 ];
 
@@ -57,32 +57,44 @@ nock(/example\.com/, directoryHeaders)
   .reply(200, {
     Resources: [
       {
-        AuthorisationServers: [
+        'AuthorisationServers': [
           {
+            Id: 'aaaj4NmBD8lQxmLh2O9FLY',
             BaseApiDNSUri: 'http://aaa.example.com',
             CustomerFriendlyLogoUri: 'string',
             CustomerFriendlyName: 'AAA Example Bank',
+            OpenIDConfigEndPointUri: 'http://aaa.example.com/openid/config',
           },
         ],
-        id: 'aaa-example-org',
+        'urn:openbanking:organisation:1.0': {
+          OBOrganisationId: 'aaax5nTR33811QyQfi',
+        },
+        'id': 'aaax5nTR33811QyQfi',
       },
       {
-        AuthorisationServers: [
+        'AuthorisationServers': [
           {
+            Id: 'bbbj4NmBD8lQxmLh2O9FLY',
             BaseApiDNSUri: 'http://bbb.example.com',
             CustomerFriendlyLogoUri: 'string',
             CustomerFriendlyName: 'BBB Example Bank',
+            OpenIDConfigEndPointUri: 'http://bbb.example.com/openid/config',
           },
           {
+            Id: 'cccj4NmBD8lQxmLh2O9FLY',
             BaseApiDNSUri: 'http://ccc.example.com',
             CustomerFriendlyLogoUri: 'string',
             CustomerFriendlyName: 'CCC Example Bank',
+            OpenIDConfigEndPointUri: 'http://ccc.example.com/openid/config',
           },
         ],
-        id: 'bbbccc-example-org',
+        'urn:openbanking:organisation:1.0': {
+          OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
+        },
+        'id': 'bbbcccUB4fPIYB0k1m',
       },
       {
-        id: 'empty-example-org',
+        id: 'fPIYB0k1moGhX7tUB4',
       },
     ],
   });

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -39,65 +39,69 @@ const expectedResult = [
     orgId: 'aaax5nTR33811QyQfi',
   },
   {
-    id: 'bbbj4NmBD8lQxmLh2O9FLY',
+    id: 'bbbX7tUB4fPIYB0k1m',
     logoUri: 'string',
     name: 'BBB Example Bank',
     orgId: 'bbbcccUB4fPIYB0k1m',
   },
   {
-    id: 'cccj4NmBD8lQxmLh2O9FLY',
+    id: 'cccbN8iAsMh74sOXhk',
     logoUri: 'string',
     name: 'CCC Example Bank',
     orgId: 'bbbcccUB4fPIYB0k1m',
   },
 ];
 
+const aspspPayload = {
+  Resources: [
+    {
+      'AuthorisationServers': [
+        {
+          Id: 'aaaj4NmBD8lQxmLh2O9FLY',
+          BaseApiDNSUri: 'http://aaa.example.com',
+          CustomerFriendlyLogoUri: 'string',
+          CustomerFriendlyName: 'AAA Example Bank',
+          OpenIDConfigEndPointUri: 'http://aaa.example.com/openid/config',
+        },
+      ],
+      'urn:openbanking:organisation:1.0': {
+        OrganisationCommonName: 'AAA Group PLC',
+        OBOrganisationId: 'aaax5nTR33811QyQfi',
+      },
+      'id': 'aaax5nTR33811QyQfi',
+    },
+    {
+      'AuthorisationServers': [
+        {
+          Id: 'bbbX7tUB4fPIYB0k1m',
+          BaseApiDNSUri: 'http://bbb.example.com',
+          CustomerFriendlyLogoUri: 'string',
+          CustomerFriendlyName: 'BBB Example Bank',
+          OpenIDConfigEndPointUri: 'http://bbb.example.com/openid/config',
+        },
+        {
+          Id: 'cccbN8iAsMh74sOXhk',
+          BaseApiDNSUri: 'http://ccc.example.com',
+          CustomerFriendlyLogoUri: 'string',
+          CustomerFriendlyName: 'CCC Example Bank',
+          OpenIDConfigEndPointUri: 'http://ccc.example.com/openid/config',
+        },
+      ],
+      'urn:openbanking:organisation:1.0': {
+        OrganisationCommonName: 'BBBCCC Group PLC',
+        OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
+      },
+      'id': 'bbbcccUB4fPIYB0k1m',
+    },
+    {
+      id: 'fPIYB0k1moGhX7tUB4',
+    },
+  ],
+};
+
 nock(/example\.com/, directoryHeaders)
   .get('/scim/v2/OBAccountPaymentServiceProviders/')
-  .reply(200, {
-    Resources: [
-      {
-        'AuthorisationServers': [
-          {
-            Id: 'aaaj4NmBD8lQxmLh2O9FLY',
-            BaseApiDNSUri: 'http://aaa.example.com',
-            CustomerFriendlyLogoUri: 'string',
-            CustomerFriendlyName: 'AAA Example Bank',
-            OpenIDConfigEndPointUri: 'http://aaa.example.com/openid/config',
-          },
-        ],
-        'urn:openbanking:organisation:1.0': {
-          OBOrganisationId: 'aaax5nTR33811QyQfi',
-        },
-        'id': 'aaax5nTR33811QyQfi',
-      },
-      {
-        'AuthorisationServers': [
-          {
-            Id: 'bbbj4NmBD8lQxmLh2O9FLY',
-            BaseApiDNSUri: 'http://bbb.example.com',
-            CustomerFriendlyLogoUri: 'string',
-            CustomerFriendlyName: 'BBB Example Bank',
-            OpenIDConfigEndPointUri: 'http://bbb.example.com/openid/config',
-          },
-          {
-            Id: 'cccj4NmBD8lQxmLh2O9FLY',
-            BaseApiDNSUri: 'http://ccc.example.com',
-            CustomerFriendlyLogoUri: 'string',
-            CustomerFriendlyName: 'CCC Example Bank',
-            OpenIDConfigEndPointUri: 'http://ccc.example.com/openid/config',
-          },
-        ],
-        'urn:openbanking:organisation:1.0': {
-          OBOrganisationId: 'bbbcccUB4fPIYB0k1m',
-        },
-        'id': 'bbbcccUB4fPIYB0k1m',
-      },
-      {
-        id: 'fPIYB0k1moGhX7tUB4',
-      },
-    ],
-  });
+  .reply(200, aspspPayload);
 
 const login = application => request(application)
   .post('/login')

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -10,6 +10,9 @@ const authorisationServersData = [
       OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName',
       OrganisationCommonName: 'testOrg',
+      AuthorityId: 'FCA',
+      MemberState: 'GB',
+      RegistrationId: '123',
     },
     clientCredentials: { ex: 'ample' },
     openIdConfig: { ex: 'ample' },
@@ -21,6 +24,9 @@ const authorisationServersData = [
       OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName2',
       OrganisationCommonName: 'testOrg2',
+      AuthorityId: 'FCA',
+      MemberState: 'GB',
+      RegistrationId: '456',
     },
   },
 ];
@@ -42,7 +48,7 @@ describe('authServerRows', () => {
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
-        ['id\tCustomerFriendlyName\tOrganisationCommonName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
+        ['id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
       );
     });
   });
@@ -56,15 +62,15 @@ describe('authServerRows', () => {
       const rows = await authServerRows();
       assert.deepEqual(
         rows[0],
-        'id\tCustomerFriendlyName\tOrganisationCommonName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
+        'id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
       );
       assert.deepEqual(
         rows[1],
-        'testId\ttestName\ttestOrg\ttestOrdId\ttrue\ttrue',
+        'testId\ttestName\ttestOrg\tGB:FCA:123\ttestOrdId\ttrue\ttrue',
       );
       assert.deepEqual(
         rows[2],
-        'testId2\ttestName2\ttestOrg2\ttestOrdId\tfalse\tfalse',
+        'testId2\ttestName2\ttestOrg2\tGB:FCA:456\ttestOrdId\tfalse\tfalse',
       );
     });
   });

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -7,7 +7,7 @@ const authorisationServersData = [
     id: 'testId',
     obDirectoryConfig: {
       id: 'testId',
-      orgId: 'testOrdId',
+      OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName',
     },
     clientCredentials: { ex: 'ample' },
@@ -17,7 +17,7 @@ const authorisationServersData = [
     id: 'testId2',
     obDirectoryConfig: {
       id: 'testId2',
-      orgId: 'testOrdId',
+      OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName2',
     },
   },
@@ -40,7 +40,7 @@ describe('authServerRows', () => {
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
-        ['id\tCustomerFriendlyName\torgId\tclientCredentialsPresent\topenIdConfigPresent'],
+        ['id\tCustomerFriendlyName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
       );
     });
   });
@@ -51,13 +51,18 @@ describe('authServerRows', () => {
     });
 
     it('returns tsv of auth servers', async () => {
+      const rows = await authServerRows();
       assert.deepEqual(
-        await authServerRows(),
-        [
-          'id\tCustomerFriendlyName\torgId\tclientCredentialsPresent\topenIdConfigPresent',
-          'testId\ttestName\ttestOrdId\ttrue\ttrue',
-          'testId2\ttestName2\ttestOrdId\tfalse\tfalse',
-        ],
+        rows[0],
+        'id\tCustomerFriendlyName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
+      );
+      assert.deepEqual(
+        rows[1],
+        'testId\ttestName\ttestOrdId\ttrue\ttrue',
+      );
+      assert.deepEqual(
+        rows[2],
+        'testId2\ttestName2\ttestOrdId\tfalse\tfalse',
       );
     });
   });

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -9,6 +9,7 @@ const authorisationServersData = [
       id: 'testId',
       OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName',
+      OrganisationCommonName: 'testOrg',
     },
     clientCredentials: { ex: 'ample' },
     openIdConfig: { ex: 'ample' },
@@ -19,6 +20,7 @@ const authorisationServersData = [
       id: 'testId2',
       OBOrganisationId: 'testOrdId',
       CustomerFriendlyName: 'testName2',
+      OrganisationCommonName: 'testOrg2',
     },
   },
 ];
@@ -40,7 +42,7 @@ describe('authServerRows', () => {
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
-        ['id\tCustomerFriendlyName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
+        ['id\tCustomerFriendlyName\tOrganisationCommonName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
       );
     });
   });
@@ -54,15 +56,15 @@ describe('authServerRows', () => {
       const rows = await authServerRows();
       assert.deepEqual(
         rows[0],
-        'id\tCustomerFriendlyName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
+        'id\tCustomerFriendlyName\tOrganisationCommonName\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
       );
       assert.deepEqual(
         rows[1],
-        'testId\ttestName\ttestOrdId\ttrue\ttrue',
+        'testId\ttestName\ttestOrg\ttestOrdId\ttrue\ttrue',
       );
       assert.deepEqual(
         rows[2],
-        'testId2\ttestName2\ttestOrdId\tfalse\tfalse',
+        'testId2\ttestName2\ttestOrg2\ttestOrdId\tfalse\tfalse',
       );
     });
   });


### PR DESCRIPTION
- Use authorisation server `Id` from OB Directory
- Store `OBOrganisationId` and `OrganisationCommonName` in db
- Store `AuthorityId`, `MemberState`, `RegistrationId` in db
- Update list auth server script to print `OBOrganisationId`, `OrganisationCommonName`, `AuthorityId`
- Rename `AUTH_SERVER_COLLECTION` to `ASPSP_AUTH_SERVERS_COLLECTION`

Completes: REFAPP-84

Tested successfully against our mock server, and against OB Directory.