### PR TITLE
REFAPP-90 - Configure MTLS in heroku to get Ozone openIdConfig

### DIFF
--- a/app/authorisation-code-granted.js
+++ b/app/authorisation-code-granted.js
@@ -2,7 +2,7 @@ const env = require('env-var');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('./authorisation-servers');
 
-const redirectionUrl = `${env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString()}`;
+const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
 const authServer = env.get('ASPSP_AUTH_SERVER').asString();
 
 const authorisationServerHost = async authServerId => (authServerId ? authServer : null);

--- a/app/authorisation-servers/openid-config.js
+++ b/app/authorisation-servers/openid-config.js
@@ -4,8 +4,7 @@ const { setupMutualTLS } = require('../certs-util');
 
 const getOpenIdConfig = async (url) => {
   log(`GET ${url}`);
-  const response = await setupMutualTLS(request)
-    .get(url)
+  const response = await setupMutualTLS(request.get(url))
     .set('accept', 'application/json; charset=utf-8')
     .send();
   return response.body;

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -66,8 +66,7 @@ const getAccessToken = async () => {
     createdJwt.setHeader('kid', softwareStatementAssertionKid);
     const compactedJwt = createdJwt.compact();
 
-    const response = await setupMutualTLS(request)
-      .post(authUrl)
+    const response = await setupMutualTLS(request.post(authUrl))
       .send(qs.stringify({
         client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
         grant_type: 'client_credentials',
@@ -97,8 +96,7 @@ const fetchOBAccountPaymentServiceProviders = async () => {
       (await getAccessToken()) : { token: NOT_PROVISIONED_FOR_OB_TOKEN };
     const bearerToken = `Bearer ${accessToken.token}`;
     log(`getting: ${uri}`);
-    const response = await setupMutualTLS(request)
-      .get(uri)
+    const response = await setupMutualTLS(request.get(uri))
       .set('Authorization', bearerToken)
       .set('Accept', 'application/json');
     log(`response: ${response.status}`);

--- a/test/authorisation-code-granted.test.js
+++ b/test/authorisation-code-granted.test.js
@@ -90,17 +90,4 @@ describe('Authorized Code Granted', () => {
       });
     });
   });
-
-  describe('redirect url missing', () => {
-    it('throws an error', () => {
-      try {
-        redirection = proxyquire('../app/authorisation-code-granted.js', {});
-      } catch (e) {
-        assert(
-          e.message.match(/"REGISTERED_REDIRECT_URL" is a required variable/),
-          'error message should indicate REGISTERED_REDIRECT_URL is missing',
-        );
-      }
-    });
-  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,14 +7,7 @@ process.env.DEBUG = 'error';
 process.env.ASPSP_READWRITE_HOST = 'example.com';
 process.env.AUTHORIZATION = authorization;
 process.env.X_FAPI_FINANCIAL_ID = xFapiFinancialId;
-process.env.OB_PROVISIONED = 'true';
 process.env.OB_DIRECTORY_HOST = 'http://example.com';
-process.env.OB_DIRECTORY_AUTH_HOST = 'http://auth.com';
-process.env.SOFTWARE_STATEMENT_ID = 'xxxxxxxx-xx2b-4xx3-a19a-xx9ec3baxxxx';
-process.env.SOFTWARE_STATEMENT_ASSERTION_KID = 'xxXXTm-XXxKBDuXxKoWXXX_xxxx';
-process.env.CLIENT_SCOPES = 'openid TPPReadAccess ASPSPReadAccess';
-process.env.DEMO_ONLY_PRIVATE_KEY_URL = 'http://secure-url.com/private_key.pem';
-process.env.REGISTERED_REDIRECT_URL = 'http://localhost:$PORT/tpp/authorized';
 
 const { app } = require('../app/index.js');
 const { session } = require('../app/session.js');


### PR DESCRIPTION
This is more than a config update. Calls to MTLS `superagent` where incorrect.

This is now fixed with other tidy up.

I've added the `CA`, `CERT` and `KEY` related ENVs. And, as soon as this PR is approved, I'll update `MTLS_ENABLED` to true.

See below to confirm `Ozone` both have OpenId Config,

__Referenco Bank__
```sh
$ npm run listAuthServers | grep Referenco
48fr7qwRKzA0eWKR2Se8YR	Referenco Bank	Referenco Bank - ASPSP	GB:FCA:RegBancomamaApp01	4iZQesHhScgRdgnWwE	false	true
```

__Modelo Bank__
```sh
$ npm run listAuthServers | grep Modelo
4khj4NmBD8lQxmLh2O9FLY	Modelo Bank	Modelo Bank - ASPSP	GB:FCA:RegBancopapaApp01	7umx5nTR33811QyQfi	false	true
```