### PR TITLE
Use auth and token endpoints from  openid config - REFAPP-86 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,5 @@
 PORT=8003
 DEBUG=error,log,debug
-ASPSP_AUTH_SERVER=http://localhost:8001
 ASPSP_RESOURCE_SERVER=http://localhost:8001
 ASPSP_READWRITE_HOST=localhost:8001
 OB_PROVISIONED=false

--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ Or run with environment variables set on the command line:
 
 ```sh
 DEBUG=error,log \
-  ASPSP_AUTH_SERVER=http://localhost:8001 \
   ASPSP_READWRITE_HOST=localhost:8001 \
   OB_PROVISIONED=false \
   OB_DIRECTORY_HOST=http://localhost:8001 \
@@ -289,7 +288,6 @@ heroku create --region eu <newname>
 heroku addons:create redistogo # or any other redis add-on
 heroku addons:create mongolab:sandbox
 
-heroku config:set ASPSP_AUTH_SERVER=http://aspsp-auth-server.example.com
 heroku config:set ASPSP_READWRITE_HOST=aspsp-resource-server.example.com
 heroku config:set ASPSP_RESOURCE_SERVER=http://aspsp-resource-server.example.com
 heroku config:set AUTHORIZATION=<mock-token>

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -15,16 +15,6 @@ const statePayload = (authorisationServerId, sessionId) => {
   return Buffer.from(JSON.stringify(state)).toString('base64');
 };
 
-const authorisationServerEndpoint = async (authServerId) => {
-  const url = await authorisationEndpoint(authServerId);
-  if (url === null) {
-    const err = new Error(`authorisationEndpoint for ${authServerId} not found`);
-    err.status = 500;
-    throw err;
-  }
-  return url;
-};
-
 const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
@@ -37,7 +27,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
 
     const state = statePayload(authorisationServerId, sessionId);
     const scope = 'openid accounts';
-    const authServerEndpoint = await authorisationServerEndpoint(authorisationServerId);
+    const authServerEndpoint = await authorisationEndpoint(authorisationServerId);
     const payload = createClaims(
       scope, accountRequestId, clientId, authServerEndpoint,
       registeredRedirectUrl, state, createClaims,
@@ -62,4 +52,3 @@ const accountRequestAuthoriseConsent = async (req, res) => {
 
 exports.statePayload = statePayload;
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
-exports.authorisationServerEndpoint = authorisationServerEndpoint;

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -62,3 +62,4 @@ const accountRequestAuthoriseConsent = async (req, res) => {
 
 exports.statePayload = statePayload;
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
+exports.authorisationServerEndpoint = authorisationServerEndpoint;

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -1,5 +1,6 @@
 const { setupAccountRequest, clientCredentials } = require('./setup-account-request');
 const { createClaims, createJsonWebSignature } = require('./authorise');
+const { authorisationEndpoint } = require('./authorisation-servers');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
 const env = require('env-var');
@@ -14,8 +15,15 @@ const statePayload = (authorisationServerId, sessionId) => {
   return Buffer.from(JSON.stringify(state)).toString('base64');
 };
 
-// Todo: lookup auth server via Directory and OpenIdEndpoint responses.
-const authorisationServerEndpoint = async authServerId => (authServerId ? `${process.env.ASPSP_AUTH_SERVER}/authorize` : null);
+const authorisationServerEndpoint = async (authServerId) => {
+  const url = await authorisationEndpoint(authServerId);
+  if (url === null) {
+    const err = new Error(`authorisationEndpoint for ${authServerId} not found`);
+    err.status = 500;
+    throw err;
+  }
+  return url;
+};
 
 const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/app/authorisation-code-granted.js
+++ b/app/authorisation-code-granted.js
@@ -1,6 +1,6 @@
 const env = require('env-var');
 const { postToken } = require('./obtain-access-token');
-const { getClientCredentials, authorisationEndpoint } = require('./authorisation-servers');
+const { getClientCredentials } = require('./authorisation-servers');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
 
@@ -8,7 +8,6 @@ const handler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, code } = req.query;
-    const authorisationUrl = await authorisationEndpoint(authorisationServerId);
     const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
     const accessTokenPayload = {
       grant_type: 'authorization_code',
@@ -16,7 +15,7 @@ const handler = async (req, res) => {
       code,
     };
 
-    await postToken(authorisationUrl, clientId, clientSecret, accessTokenPayload);
+    await postToken(authorisationServerId, clientId, clientSecret, accessTokenPayload);
     return res.status(204).send();
   } catch (err) {
     const status = err.status ? err.status : 500;

--- a/app/authorisation-code-granted.js
+++ b/app/authorisation-code-granted.js
@@ -1,7 +1,6 @@
 const env = require('env-var');
 const { postToken } = require('./obtain-access-token');
-const { getClientCredentials } = require('./authorisation-servers');
-const { authorisationServerEndpoint } = require('./account-request-authorise-consent');
+const { getClientCredentials, authorisationEndpoint } = require('./authorisation-servers');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
 
@@ -9,7 +8,7 @@ const handler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, code } = req.query;
-    const authorisationUrl = await authorisationServerEndpoint(authorisationServerId);
+    const authorisationUrl = await authorisationEndpoint(authorisationServerId);
     const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
     const accessTokenPayload = {
       grant_type: 'authorization_code',

--- a/app/authorisation-code-granted.js
+++ b/app/authorisation-code-granted.js
@@ -1,17 +1,15 @@
 const env = require('env-var');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('./authorisation-servers');
+const { authorisationServerEndpoint } = require('./account-request-authorise-consent');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
-const authServer = env.get('ASPSP_AUTH_SERVER').asString();
-
-const authorisationServerHost = async authServerId => (authServerId ? authServer : null);
 
 const handler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, code } = req.query;
-    const authorizationServerHost = await authorisationServerHost(authorisationServerId);
+    const authorisationUrl = await authorisationServerEndpoint(authorisationServerId);
     const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
     const accessTokenPayload = {
       grant_type: 'authorization_code',
@@ -19,7 +17,7 @@ const handler = async (req, res) => {
       code,
     };
 
-    await postToken(authorizationServerHost, clientId, clientSecret, accessTokenPayload);
+    await postToken(authorisationUrl, clientId, clientSecret, accessTokenPayload);
     return res.status(204).send();
   } catch (err) {
     const status = err.status ? err.status : 500;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -118,10 +118,21 @@ const authorisationEndpoint = async (id) => {
   }
 };
 
+const tokenEndpoint = async (id) => {
+  try {
+    const config = await getAuthServerConfig(id);
+    return config.openIdConfig ? config.openIdConfig.token_endpoint : null;
+  } catch (err) {
+    error(err);
+    return null;
+  }
+};
+
 exports.authorisationEndpoint = authorisationEndpoint;
 exports.storeAuthorisationServers = storeAuthorisationServers;
 exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
+exports.tokenEndpoint = tokenEndpoint;
 exports.updateOpenIdConfigs = updateOpenIdConfigs;
 exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -108,6 +108,17 @@ const authorisationServersForClient = async () => {
   }
 };
 
+const authorisationEndpoint = async (id) => {
+  try {
+    const config = await getAuthServerConfig(id);
+    return config.openIdConfig ? config.openIdConfig.authorization_endpoint : null;
+  } catch (err) {
+    error(err);
+    return null;
+  }
+};
+
+exports.authorisationEndpoint = authorisationEndpoint;
 exports.storeAuthorisationServers = storeAuthorisationServers;
 exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -108,24 +108,24 @@ const authorisationServersForClient = async () => {
   }
 };
 
-const authorisationEndpoint = async (id) => {
+const openIdConfig = async (id) => {
   try {
     const config = await getAuthServerConfig(id);
-    return config.openIdConfig ? config.openIdConfig.authorization_endpoint : null;
+    return (config && config.openIdConfig) ? config.openIdConfig : null;
   } catch (err) {
     error(err);
     return null;
   }
 };
 
+const authorisationEndpoint = async (id) => {
+  const config = await openIdConfig(id);
+  return config ? config.authorization_endpoint : null;
+};
+
 const tokenEndpoint = async (id) => {
-  try {
-    const config = await getAuthServerConfig(id);
-    return config.openIdConfig ? config.openIdConfig.token_endpoint : null;
-  } catch (err) {
-    error(err);
-    return null;
-  }
+  const config = await openIdConfig(id);
+  return config ? config.token_endpoint : null;
 };
 
 exports.authorisationEndpoint = authorisationEndpoint;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -125,12 +125,24 @@ const openIdConfig = async (id) => {
 
 const authorisationEndpoint = async (id) => {
   const config = await openIdConfig(id);
-  return config ? config.authorization_endpoint : null;
+  const endpoint = config ? config.authorization_endpoint : null;
+  if (endpoint === null) {
+    const err = new Error(`authorisation endpoint for auth server ${id} not found`);
+    err.status = 500;
+    throw err;
+  }
+  return endpoint;
 };
 
 const tokenEndpoint = async (id) => {
   const config = await openIdConfig(id);
-  return config ? config.token_endpoint : null;
+  const endpoint = config ? config.token_endpoint : null;
+  if (endpoint === null) {
+    const err = new Error(`token endpoint for auth server ${id} not found`);
+    err.status = 500;
+    throw err;
+  }
+  return endpoint;
 };
 
 exports.authorisationEndpoint = authorisationEndpoint;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -36,7 +36,12 @@ const setAuthServerConfig = async (id, authServer) =>
 
 const getClientCredentials = async (authServerId) => {
   const authServer = await getAuthServerConfig(authServerId);
-  return authServer.clientCredentials;
+  if (authServer && authServer.clientCredentials) {
+    return authServer.clientCredentials;
+  }
+  const err = new Error(`clientCredentials not found for ${authServerId}`);
+  err.status = 500;
+  throw err;
 };
 
 const storeAuthorisationServers = async (list) => {

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -3,6 +3,7 @@ const {
   authorisationEndpoint,
   authorisationServersForClient,
   storeAuthorisationServers,
+  tokenEndpoint,
   updateOpenIdConfigs,
   getClientCredentials,
   updateClientCredentials,
@@ -12,6 +13,7 @@ exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
 exports.authorisationEndpoint = authorisationEndpoint;
 exports.storeAuthorisationServers = storeAuthorisationServers;
+exports.tokenEndpoint = tokenEndpoint;
 exports.updateOpenIdConfigs = updateOpenIdConfigs;
 exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -1,5 +1,6 @@
 const {
   allAuthorisationServers,
+  authorisationEndpoint,
   authorisationServersForClient,
   storeAuthorisationServers,
   updateOpenIdConfigs,
@@ -9,6 +10,7 @@ const {
 
 exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
+exports.authorisationEndpoint = authorisationEndpoint;
 exports.storeAuthorisationServers = storeAuthorisationServers;
 exports.updateOpenIdConfigs = updateOpenIdConfigs;
 exports.getClientCredentials = getClientCredentials;

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,9 +1,8 @@
 const { postToken } = require('../obtain-access-token');
 const { postAccountRequests } = require('./account-requests');
-const { getClientCredentials } = require('../authorisation-servers');
+const { getClientCredentials, authorisationEndpoint } = require('../authorisation-servers');
 const env = require('env-var');
 const debug = require('debug')('debug');
-const { authorisationServerEndpoint } = require('../account-request-authorise-consent');
 
 // Todo: lookup resource server via Directory and OpenIdEndpoint responses.
 const resourceServerPath = async (authorisationServerId) => {
@@ -33,7 +32,7 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
 
 // Returns access-token when request successful
 const createAccessToken = async (authorisationServerId) => {
-  const authorisationServer = await authorisationServerEndpoint(authorisationServerId);
+  const authorisationServer = await authorisationEndpoint(authorisationServerId);
   const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
   const accessTokenPayload = {
     scope: 'accounts',

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -3,11 +3,7 @@ const { postAccountRequests } = require('./account-requests');
 const { getClientCredentials } = require('../authorisation-servers');
 const env = require('env-var');
 const debug = require('debug')('debug');
-
-const authServer = env.get('ASPSP_AUTH_SERVER').asString();
-
-// Todo: lookup auth server via Directory and OpenIdEndpoint responses.
-const authorisationServerHost = async authServerId => (authServerId ? authServer : null);
+const { authorisationServerEndpoint } = require('../account-request-authorise-consent');
 
 // Todo: lookup resource server via Directory and OpenIdEndpoint responses.
 const resourceServerPath = async (authorisationServerId) => {
@@ -37,7 +33,7 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
 
 // Returns access-token when request successful
 const createAccessToken = async (authorisationServerId) => {
-  const authorisationServer = await authorisationServerHost(authorisationServerId);
+  const authorisationServer = await authorisationServerEndpoint(authorisationServerId);
   const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
   const accessTokenPayload = {
     scope: 'accounts',

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,6 +1,6 @@
 const { postToken } = require('../obtain-access-token');
 const { postAccountRequests } = require('./account-requests');
-const { getClientCredentials, authorisationEndpoint } = require('../authorisation-servers');
+const { getClientCredentials } = require('../authorisation-servers');
 const env = require('env-var');
 const debug = require('debug')('debug');
 
@@ -32,7 +32,6 @@ const validateParameters = (authorisationServerId, fapiFinancialId) => {
 
 // Returns access-token when request successful
 const createAccessToken = async (authorisationServerId) => {
-  const authorisationServer = await authorisationEndpoint(authorisationServerId);
   const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
   const accessTokenPayload = {
     scope: 'accounts',
@@ -40,7 +39,7 @@ const createAccessToken = async (authorisationServerId) => {
   };
 
   const response = await postToken(
-    authorisationServer,
+    authorisationServerId,
     clientId,
     clientSecret,
     accessTokenPayload,

--- a/test/authorisation-code-granted.test.js
+++ b/test/authorisation-code-granted.test.js
@@ -22,19 +22,21 @@ describe('Authorized Code Granted', () => {
   let redirection;
   let postTokenStub;
   let getClientCredentialsStub;
+  let authorisationServerEndpointStub;
   let request;
   let response;
 
   beforeEach(() => {
     postTokenStub = sinon.stub().returns({ access_token: accessToken });
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
+    authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
     redirection = proxyquire('../app/authorisation-code-granted.js', {
       'env-var': env.mock({
         SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
-        ASPSP_AUTH_SERVER: authServerHost,
       }),
       './obtain-access-token': { postToken: postTokenStub },
       './authorisation-servers': { getClientCredentials: getClientCredentialsStub },
+      './account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
     });
 
     request = httpMocks.createRequest({
@@ -72,13 +74,14 @@ describe('Authorized Code Granted', () => {
       beforeEach(() => {
         postTokenStub = sinon.stub().throws(error);
         getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
+        authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
         redirection = proxyquire('../app/authorisation-code-granted.js', {
           'env-var': env.mock({
             SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
-            ASPSP_AUTH_SERVER: authServerHost,
           }),
           './obtain-access-token': { postToken: postTokenStub },
           './authorisation-servers': { getClientCredentials: getClientCredentialsStub },
+          './account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
         });
       });
 

--- a/test/authorisation-code-granted.test.js
+++ b/test/authorisation-code-granted.test.js
@@ -22,21 +22,23 @@ describe('Authorized Code Granted', () => {
   let redirection;
   let postTokenStub;
   let getClientCredentialsStub;
-  let authorisationServerEndpointStub;
+  let authorisationEndpointStub;
   let request;
   let response;
 
   beforeEach(() => {
     postTokenStub = sinon.stub().returns({ access_token: accessToken });
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
-    authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
+    authorisationEndpointStub = sinon.stub().returns(authServerHost);
     redirection = proxyquire('../app/authorisation-code-granted.js', {
       'env-var': env.mock({
         SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
       }),
       './obtain-access-token': { postToken: postTokenStub },
-      './authorisation-servers': { getClientCredentials: getClientCredentialsStub },
-      './account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
+      './authorisation-servers': {
+        getClientCredentials: getClientCredentialsStub,
+        authorisationEndpoint: authorisationEndpointStub,
+      },
     });
 
     request = httpMocks.createRequest({
@@ -74,14 +76,16 @@ describe('Authorized Code Granted', () => {
       beforeEach(() => {
         postTokenStub = sinon.stub().throws(error);
         getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
-        authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
+        authorisationEndpointStub = sinon.stub().returns(authServerHost);
         redirection = proxyquire('../app/authorisation-code-granted.js', {
           'env-var': env.mock({
             SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
           }),
           './obtain-access-token': { postToken: postTokenStub },
-          './authorisation-servers': { getClientCredentials: getClientCredentialsStub },
-          './account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
+          './authorisation-servers': {
+            getClientCredentials: getClientCredentialsStub,
+            authorisationEndpoint: authorisationEndpointStub,
+          },
         });
       });
 

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -106,6 +106,20 @@ describe('authorisation servers', () => {
     });
   });
 
+  describe('authorisationEndpoint called with invalid authServerId', () => {
+    it('returns null', async () => {
+      assert.equal(await authorisationEndpoint(null), null);
+      assert.equal(await authorisationEndpoint('invalid-id'), null);
+    });
+  });
+
+  describe('tokenEndpoint called with invalid authServerId', () => {
+    it('returns null', async () => {
+      assert.equal(await tokenEndpoint(null), null);
+      assert.equal(await tokenEndpoint('invalid-id'), null);
+    });
+  });
+
   describe('updateOpenIdConfigs', () => {
     nock(/example\.com/)
       .get('/openidconfig')

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -111,15 +111,23 @@ describe('authorisation servers', () => {
 
   describe('authorisationEndpoint called with invalid authServerId', () => {
     it('returns null', async () => {
-      assert.equal(await authorisationEndpoint(null), null);
-      assert.equal(await authorisationEndpoint('invalid-id'), null);
+      try {
+        await authorisationEndpoint('invalid-id');
+        assert.ok(false);
+      } catch (err) {
+        assert.equal(err.status, 500);
+      }
     });
   });
 
   describe('tokenEndpoint called with invalid authServerId', () => {
     it('returns null', async () => {
-      assert.equal(await tokenEndpoint(null), null);
-      assert.equal(await tokenEndpoint('invalid-id'), null);
+      try {
+        await tokenEndpoint('invalid-id');
+        assert.ok(false);
+      } catch (err) {
+        assert.equal(err.status, 500);
+      }
     });
   });
 
@@ -132,12 +140,6 @@ describe('authorisation servers', () => {
       const list = await allAuthorisationServers();
       const authServerConfig = list[0];
       assert.ok(!authServerConfig.openIdConfig, 'openIdConfig not present');
-
-      const authEndpoint = await authorisationEndpoint(authServerId);
-      assert.equal(authEndpoint, null);
-
-      const tokenUrl = await tokenEndpoint(authServerId);
-      assert.equal(tokenUrl, null);
     });
 
     it('retrieves openIdConfig and stores in db', async () => {

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -76,6 +76,17 @@ describe('authorisation servers', () => {
       await updateClientCredentials(authServerId, clientCredentials);
     });
 
+    describe('called with invalid authServerId', () => {
+      it('throws error', async () => {
+        try {
+          await getClientCredentials('invalid-id');
+          assert.ok(false);
+        } catch (err) {
+          assert.equal(err.status, 500);
+        }
+      });
+    });
+
     it('retrieves client credentials for an authorisationServerId', async () => {
       const found = await getClientCredentials(authServerId);
       assert.deepEqual(found, clientCredentials);

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const { drop, set } = require('../../app/storage.js');
+const { drop } = require('../../app/storage.js');
 const { ASPSP_AUTH_SERVERS_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
 const {
   allAuthorisationServers,
@@ -72,20 +72,12 @@ describe('authorisation servers', () => {
   });
 
   describe('getClientCredentials', () => {
-    let authorisationServerId;
     beforeEach(async () => {
-      const list = await allAuthorisationServers();
-      const authServer = list[0];
-      authorisationServerId = list[0].id;
-      await set(
-        ASPSP_AUTH_SERVERS_COLLECTION,
-        Object.assign(authServer, { clientCredentials }),
-        authorisationServerId,
-      );
+      await updateClientCredentials(authServerId, clientCredentials);
     });
 
     it('retrieves client credentials for an authorisationServerId', async () => {
-      const found = await getClientCredentials(authorisationServerId);
+      const found = await getClientCredentials(authServerId);
       assert.deepEqual(found, clientCredentials);
     });
   });

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -6,6 +6,7 @@ const {
   allAuthorisationServers,
   authorisationEndpoint,
   storeAuthorisationServers,
+  tokenEndpoint,
   updateOpenIdConfigs,
   getClientCredentials,
   updateClientCredentials,
@@ -25,9 +26,10 @@ const flattenedObDirectoryAuthServerList = [
 ];
 
 const expectedAuthEndpoint = 'http://auth.example.com/authorize';
+const expectedTokenEndpoint = 'http://auth.example.com/token';
 const openIdConfig = {
   authorization_endpoint: expectedAuthEndpoint,
-  token_endpoint: 'http://auth.example.com/token',
+  token_endpoint: expectedTokenEndpoint,
 };
 
 const clientCredentials = {
@@ -116,6 +118,9 @@ describe('authorisation servers', () => {
 
       const authEndpoint = await authorisationEndpoint(authServerId);
       assert.equal(authEndpoint, null);
+
+      const tokenUrl = await tokenEndpoint(authServerId);
+      assert.equal(tokenUrl, null);
     });
 
     it('retrieves openIdConfig and stores in db', async () => {
@@ -127,6 +132,9 @@ describe('authorisation servers', () => {
 
       const authEndpoint = await authorisationEndpoint(authServerId);
       assert.equal(authEndpoint, expectedAuthEndpoint);
+
+      const tokenUrl = await tokenEndpoint(authServerId);
+      assert.equal(tokenUrl, expectedTokenEndpoint);
     });
   });
 });

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -4,6 +4,7 @@ const { drop, set } = require('../../app/storage.js');
 const { ASPSP_AUTH_SERVERS_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
 const {
   allAuthorisationServers,
+  authorisationEndpoint,
   storeAuthorisationServers,
   updateOpenIdConfigs,
   getClientCredentials,
@@ -23,8 +24,9 @@ const flattenedObDirectoryAuthServerList = [
   },
 ];
 
+const expectedAuthEndpoint = 'http://auth.example.com/authorize';
 const openIdConfig = {
-  authorization_endpoint: 'http://auth.example.com/authorize',
+  authorization_endpoint: expectedAuthEndpoint,
   token_endpoint: 'http://auth.example.com/token',
 };
 
@@ -111,6 +113,9 @@ describe('authorisation servers', () => {
       const list = await allAuthorisationServers();
       const authServerConfig = list[0];
       assert.ok(!authServerConfig.openIdConfig, 'openIdConfig not present');
+
+      const authEndpoint = await authorisationEndpoint(authServerId);
+      assert.equal(authEndpoint, null);
     });
 
     it('retrieves openIdConfig and stores in db', async () => {
@@ -119,6 +124,9 @@ describe('authorisation servers', () => {
       const authServerConfig = list[0];
       assert.ok(authServerConfig.openIdConfig, 'openIdConfig present');
       assert.deepEqual(authServerConfig, withOpenIdConfig);
+
+      const authEndpoint = await authorisationEndpoint(authServerId);
+      assert.equal(authEndpoint, expectedAuthEndpoint);
     });
   });
 });

--- a/test/authorise/request-jws.test.js
+++ b/test/authorise/request-jws.test.js
@@ -12,12 +12,7 @@ describe('createClaims', () => {
   const authorisationServerId = 'testAuthorisationServerId';
   const sessionId = 'testSessionId';
   const state = statePayload(authorisationServerId, sessionId);
-  before(() => {
-    process.env.ASPSP_AUTH_SERVER = 'http://example.com';
-  });
-  after(() => {
-    process.env.ASPSP_AUTH_SERVER = 'http://example.com';
-  });
+
   const expectedClaims = issuer => ({
     aud: clientId,
     iss: issuer,

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -33,7 +33,6 @@ describe('setupAccountRequest called with blank fapiFinancialId', () => {
 
 describe('setupAccountRequest called with authorisationServerId and fapiFinancialId', () => {
   const accessToken = 'access-token';
-  const authServerHost = 'http://example.com';
   const resourceServer = 'http://example.com/resources';
   const clientId = 'id';
   const clientSecret = 'secret';
@@ -49,7 +48,6 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   let tokenStub;
   let accountRequestsStub;
   let getClientCredentialsStub;
-  let authorisationEndpointStub;
   const tokenResponse = { access_token: accessToken };
   const accountRequestsResponse = status => ({
     Data: {
@@ -62,14 +60,12 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     tokenStub = sinon.stub().returns(tokenResponse);
     accountRequestsStub = sinon.stub().returns(accountRequestsResponse(status));
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
-    authorisationEndpointStub = sinon.stub().returns(authServerHost);
     setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
       'env-var': envStub,
       '../obtain-access-token': { postToken: tokenStub },
       './account-requests': { postAccountRequests: accountRequestsStub },
       '../authorisation-servers': {
         getClientCredentials: getClientCredentialsStub,
-        authorisationEndpoint: authorisationEndpointStub,
       },
     }).setupAccountRequest;
   };
@@ -81,7 +77,10 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
       const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
       assert.equal(id, accountRequestId);
 
-      assert(tokenStub.calledWithExactly(authServerHost, clientId, clientSecret, tokenPayload));
+      assert(tokenStub.calledWithExactly(
+        authorisationServerId,
+        clientId, clientSecret, tokenPayload,
+      ));
       const resourcePath = `${resourceServer}/open-banking/v1.1`;
       assert(accountRequestsStub.calledWithExactly(resourcePath, accessToken, fapiFinancialId));
     });

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -43,13 +43,13 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   };
   const accountRequestId = '88379';
   const envStub = env.mock({
-    ASPSP_AUTH_SERVER: authServerHost,
     ASPSP_RESOURCE_SERVER: resourceServer,
   });
   let setupAccountRequestProxy;
   let tokenStub;
   let accountRequestsStub;
   let getClientCredentialsStub;
+  let authorisationServerEndpointStub;
   const tokenResponse = { access_token: accessToken };
   const accountRequestsResponse = status => ({
     Data: {
@@ -62,11 +62,13 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     tokenStub = sinon.stub().returns(tokenResponse);
     accountRequestsStub = sinon.stub().returns(accountRequestsResponse(status));
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
+    authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
     setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
       'env-var': envStub,
       '../obtain-access-token': { postToken: tokenStub },
       './account-requests': { postAccountRequests: accountRequestsStub },
       '../authorisation-servers': { getClientCredentials: getClientCredentialsStub },
+      '../account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
     }).setupAccountRequest;
   };
 

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -49,7 +49,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   let tokenStub;
   let accountRequestsStub;
   let getClientCredentialsStub;
-  let authorisationServerEndpointStub;
+  let authorisationEndpointStub;
   const tokenResponse = { access_token: accessToken };
   const accountRequestsResponse = status => ({
     Data: {
@@ -62,13 +62,15 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     tokenStub = sinon.stub().returns(tokenResponse);
     accountRequestsStub = sinon.stub().returns(accountRequestsResponse(status));
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
-    authorisationServerEndpointStub = sinon.stub().returns(authServerHost);
+    authorisationEndpointStub = sinon.stub().returns(authServerHost);
     setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
       'env-var': envStub,
       '../obtain-access-token': { postToken: tokenStub },
       './account-requests': { postAccountRequests: accountRequestsStub },
-      '../authorisation-servers': { getClientCredentials: getClientCredentialsStub },
-      '../account-request-authorise-consent': { authorisationServerEndpoint: authorisationServerEndpointStub },
+      '../authorisation-servers': {
+        getClientCredentials: getClientCredentialsStub,
+        authorisationEndpoint: authorisationEndpointStub,
+      },
     }).setupAccountRequest;
   };
 


### PR DESCRIPTION
- Add functions to get `authorisationEndpoint` and `tokenEndpoint` by auth server id from openid config in db.
- Use these functions instead of `ASPSP_AUTH_SERVER` env var to construct API calls.
- These functions throw errors if configuration not found.

Completes: REFAPP-86 