### PR TITLE
Various client credentials fixes and readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,22 +84,22 @@ Here's a sample list of test ASPSPs. This is __NOT__ the raw response from the O
 ```sh
 [
   {
-    "id": "aaaj4NmBD8lQxmL",
+    "id": "aaaj4NmBD8lQxmLh2O",
     "logoUri": "",
     "name": "AAA Example Bank",
-    "orgId": "aaax5nTR33811QyQfi",
+    "orgId": "aaax5nTR33811Qy",
   },
   {
-    "id": "bbbX7tUB4fPIYB0",
+    "id": "bbbX7tUB4fPIYB0k1m",
     "logoUri": "",
     "name": "BBB Example Bank",
     "orgId": "bbbUB4fPIYB0k1m",
   },
   {
-    "id": "cccbN8iAsMh74sO",
+    "id": "cccbN8iAsMh74sOXhk",
     "logoUri": "",
     "name": "CCC Example Bank",
-    "orgId": "cccMh74sOXhk",
+    "orgId": "cccMh74sOXhkQfi",
   }
 ]
 ```
@@ -371,10 +371,10 @@ MONGODB_URI='localhost:27017/sample-tpp-server' npm run listAuthServers --silent
 
 Output on terminal is TSV that looks like this:
 ```
-id               CustomerFriendlyName OrganisationCommonName Authority  OBOrganisationId   clientCredentialsPresent openIdConfigPresent
-aaaj4NmBD8lQxmLh2O9FLY  AAA Example Bank     AAA Example PLC        GB:FCA:123 aaax5nTR33811QyQfi false                    false
-bbbX7tUB4fPIYB0k1m     BBB Example Bank     BBB Example PLC        GB:FCA:456 bbbUB4fPIYB0k1m    false                    false
-cccbN8iAsMh74sOXhk     CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh74sOXhk       false                    false
+id                 CustomerFriendlyName OrganisationCommonName Authority  OBOrganisationId clientCredentialsPresent openIdConfigPresent
+aaaj4NmBD8lQxmLh2O AAA Example Bank     AAA Example PLC        GB:FCA:123 aaax5nTR33811Qy  false                    true
+bbbX7tUB4fPIYB0k1m BBB Example Bank     BBB Example PLC        GB:FCA:456 bbbUB4fPIYB0k1m  false                    true
+cccbN8iAsMh74sOXhk CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh74sOXhkQfi  false                    true
 ```
 
 ### Adding Client Credentials for ASPSP Authorisation Servers
@@ -396,7 +396,7 @@ heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --re
 To save client credentials for the Reference Mock Server locally:
 
 ```
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O9FLY clientId=spoofClientId clientSecret=spoofClientSecret
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O clientId=spoofClientId clientSecret=spoofClientSecret
 
 MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ database.
 To list authorisation servers currently in the database, run:
 
 ```sh
-npm run listAuthServers --silent
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run listAuthServers --silent
 ```
 
 Output on terminal is TSV that looks like this:
@@ -385,7 +385,7 @@ Example Usages
 
 ```
 # Locally
-npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
 
 # Remotely
 heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --remote heroku
@@ -396,9 +396,9 @@ heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --re
 To save client credentials for the Reference Mock Server locally:
 
 ```
-npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O9FLY clientId=spoofClientId clientSecret=spoofClientSecret
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O9FLY clientId=spoofClientId clientSecret=spoofClientSecret
 
-npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
 
-npm run saveCreds authServerId=cccbN8iAsMh74sOXhk clientId=spoofClientId clientSecret=spoofClientSecret
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=cccbN8iAsMh74sOXhk clientId=spoofClientId clientSecret=spoofClientSecret
 ```

--- a/README.md
+++ b/README.md
@@ -104,21 +104,6 @@ Here's a sample list of test ASPSPs. This is __NOT__ the raw response from the O
 ]
 ```
 
-### Adding Client Credentials
-
-There is a script to input and store client credentials against ASPSP Auth Server Records
-
-Example Usages
-
-```
-# Locally
-npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
-
-# Remotely
-heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --env tpp-reference-server
-
-```
-
 ### Proxy requests for upstream backend ASPSP APIs (v1.1)
 
 __NOTE:__ For this to work you need an ASPSP server installed and running. Details in The [mock server](#the-reference-mock-server) section.
@@ -387,7 +372,33 @@ npm run listAuthServers --silent
 Output on terminal is TSV that looks like this:
 ```
 id               CustomerFriendlyName OrganisationCommonName Authority  OBOrganisationId   clientCredentialsPresent openIdConfigPresent
-aaaj4NmBD8lQxmL  AAA Example Bank     AAA Example PLC        GB:FCA:123 aaax5nTR33811QyQfi false                    false
-bbbX7tUB4fPIYB0  BBB Example Bank     BBB Example PLC        GB:FCA:456 bbbUB4fPIYB0k1m    false                    false
-cccbN8iAsMh74sO  CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh74sOXhk       false                    false
+aaaj4NmBD8lQxmLh2O9FLY  AAA Example Bank     AAA Example PLC        GB:FCA:123 aaax5nTR33811QyQfi false                    false
+bbbX7tUB4fPIYB0k1m     BBB Example Bank     BBB Example PLC        GB:FCA:456 bbbUB4fPIYB0k1m    false                    false
+cccbN8iAsMh74sOXhk     CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh74sOXhk       false                    false
+```
+
+### Adding Client Credentials for ASPSP Authorisation Servers
+
+There is a script to input and store client credentials against ASPSP Auth Server configuration.
+
+Example Usages
+
+```
+# Locally
+npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
+
+# Remotely
+heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --remote heroku
+```
+
+#### Setting client credentials for running against Reference Mock Server
+
+To save client credentials for the Reference Mock Server locally:
+
+```
+npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O9FLY clientId=spoofClientId clientSecret=spoofClientSecret
+
+npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
+
+npm run saveCreds authServerId=cccbN8iAsMh74sOXhk clientId=spoofClientId clientSecret=spoofClientSecret
 ```

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -1,6 +1,6 @@
-const { setupAccountRequest, clientCredentials } = require('./setup-account-request');
+const { setupAccountRequest } = require('./setup-account-request');
 const { createClaims, createJsonWebSignature } = require('./authorise');
-const { authorisationEndpoint } = require('./authorisation-servers');
+const { authorisationEndpoint, getClientCredentials } = require('./authorisation-servers');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
 const env = require('env-var');
@@ -23,7 +23,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
     const fapiFinancialId = req.headers['x-fapi-financial-id'];
     debug(`authorisationServerId: ${authorisationServerId}`);
     const accountRequestId = await setupAccountRequest(authorisationServerId, fapiFinancialId);
-    const { clientId } = await clientCredentials(authorisationServerId);
+    const { clientId } = await getClientCredentials(authorisationServerId);
 
     const state = statePayload(authorisationServerId, sessionId);
     const scope = 'openid accounts';

--- a/app/obtain-access-token.js
+++ b/app/obtain-access-token.js
@@ -2,6 +2,7 @@ const request = require('superagent');
 const { setupMutualTLS } = require('./certs-util');
 const { tokenEndpoint } = require('./authorisation-servers');
 const log = require('debug')('log');
+const debug = require('debug')('debug');
 const error = require('debug')('error');
 
 // Use Basic Authentication Scheme: https://tools.ietf.org/html/rfc2617#section-2
@@ -26,7 +27,9 @@ const postToken = async (authorisationServerId, clientId, clientSecret, payload)
       .set('authorization', authCredentials)
       .set('content-type', 'application/x-www-form-urlencoded')
       .send(payload);
-    return response.body;
+    const data = response.body;
+    debug(`token response: ${JSON.stringify(data)}`);
+    return data;
   } catch (err) {
     error(err);
     const e = new Error(err.message);

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -70,4 +70,3 @@ const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
 };
 
 exports.setupAccountRequest = setupAccountRequest;
-exports.clientCredentials = getClientCredentials;

--- a/app/storage.js
+++ b/app/storage.js
@@ -1,10 +1,12 @@
 const monk = require('monk');
 const error = require('debug')('error');
+const log = require('debug')('log');
 
 let mongodbUri = 'localhost:27017/sample-tpp-server';
 if (process.env.MONGODB_URI) {
   mongodbUri = process.env.MONGODB_URI.replace('mongodb://', '');
 }
+log(`MONGODB_URI: ${mongodbUri}`);
 const db = monk(mongodbUri);
 
 /**

--- a/test/account-request-authorise-consent.test.js
+++ b/test/account-request-authorise-consent.test.js
@@ -9,7 +9,7 @@ const env = require('env-var');
 const authorisationServerId = '123';
 
 const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
-  const clientCredentialsStub = sinon.stub().returns({ clientId: 'testClientId' });
+  const clientCredentialsStub = sinon.stub().returns({ clientId: 'testClientId', clientSecret: 'testClientSecret' });
   const createJsonWebSignatureStub = sinon.stub().returns('testSignedPayload');
   const { accountRequestAuthoriseConsent } = proxyquire(
     '../app/account-request-authorise-consent',
@@ -19,13 +19,13 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
       }),
       './setup-account-request': {
         setupAccountRequest: setupAccountRequestStub,
-        clientCredentials: clientCredentialsStub,
       },
       './authorise': {
         createJsonWebSignature: createJsonWebSignatureStub,
       },
       './authorisation-servers': {
         authorisationEndpoint: authorisationEndpointStub,
+        getClientCredentials: clientCredentialsStub,
       },
     },
   );


### PR DESCRIPTION
- Add how to set client credentials for mock server to readme
- Log mongodb URI for debugging
- Use correct getClientCredentials function for /authorize URL creation
- Add MONGODB_URI setting to script examples in readme
- Use new dummy data ids from mock server in readme examples