### PR TITLE
Ref #REFAPP-42 Return only ASPSP Authorisation Servers with Client Credentials Registered

### DIFF
--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -104,8 +104,9 @@ const updateOpenIdConfigs = async () => {
 
 const authorisationServersForClient = async () => {
   try {
-    const list = await allAuthorisationServers();
-    const servers = list.map(a => transformServerData(a.obDirectoryConfig));
+    const allServers = await allAuthorisationServers();
+    const registeredServers = allServers.filter(s => s.clientCredentials);
+    const servers = registeredServers.map(s => transformServerData(s.obDirectoryConfig));
     return sortByName(servers);
   } catch (e) {
     error(e);

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -189,10 +189,7 @@ describe('Directory', () => {
         .set('authorization', sessionId)
         .end((e, r) => {
           assert.equal(r.status, 200);
-          assert.equal(r.body.length, expectedResult.length, `expected ${expectedResult.length} results, got ${r.body.length}`);
-          assert.deepEqual(r.body[0], expectedResult[0]);
-          assert.deepEqual(r.body[1], expectedResult[1]);
-          assert.deepEqual(r.body[2], expectedResult[2]);
+          assert.equal(r.body.length, 0, `expected ${expectedResult.length} results, got ${r.body.length}`);
           const header = r.headers['access-control-allow-origin'];
           assert.equal(header, '*');
           done();


### PR DESCRIPTION


Test modified - separate task - decouple the code to untangle the caching etc and make the credentials adding testable

