### PR TITLE
REFAPP-103 Create a script to bootstrap AuthServer & OpenID Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,12 +340,27 @@ The server has to be configured with
 
 ## Configuration of ASPSP Authorisation Servers
 
-When the `/account-payment-service-provider-authorisation-servers` endpoint is
-called on the server, a list of ASPSP authorisation servers is fetched from
-OB Directory and stored in the server's database.
+### Adding and Updating ASPSP authorisation servers
 
-For each authorisation server the OpenId config is fetched and stored in the
-database.
+Bootstrapping or updating the list of ASPSP authorisation servers in MongoDB is a manual task. For each authorisation server the OpenId config is also fetched and stored in the database.
+
+You have to ensure all the necessary ENVs are configured correctly and then run:
+
+```sh
+# Locally
+MONGODB_URI='localhost:27017/sample-tpp-server' npm run updateAuthServersAndOpenIds
+
+# Remotely on Heroku
+heroku run npm run updateAuthServersAndOpenIds --remote heroku
+```
+
+Now calling the `/account-payment-service-provider-authorisation-servers` endpoint returns the correctly formatted list of ASPSP authorisation servers previously fetched from OB Directory.
+
+> __NOTE__
+
+> If you don't add client credentials you will get an EMPTY ASPSP server list.
+
+### Listing available ASPSP authorisation servers
 
 To list authorisation servers currently in the database, run:
 

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -10,7 +10,6 @@ const error = require('debug')('error');
 const {
   authorisationServersForClient,
   storeAuthorisationServers,
-  updateOpenIdConfigs,
 } = require('./authorisation-servers');
 
 const NOT_PROVISIONED_FOR_OB_TOKEN = 'NO_TOKEN';
@@ -115,17 +114,11 @@ const fetchOBAccountPaymentServiceProviders = async () => {
 
 const OBAccountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  let servers = await authorisationServersForClient();
+  const servers = await authorisationServersForClient();
   log(`servers length: ${servers.length}`);
-  if (servers.length > 0) {
-    fetchOBAccountPaymentServiceProviders() // async update auth servers
-      .then(() => updateOpenIdConfigs()); // async update openId configs
-  } else {
-    servers = await fetchOBAccountPaymentServiceProviders(); // fetch auth servers
-    await updateOpenIdConfigs(); // fetch openid configs
-  }
   return res.json(servers);
 };
 
 exports.extractAuthorisationServers = extractAuthorisationServers;
+exports.fetchOBAccountPaymentServiceProviders = fetchOBAccountPaymentServiceProviders;
 exports.OBAccountPaymentServiceProviders = OBAccountPaymentServiceProviders;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "eslint": "node ./node_modules/eslint/bin/eslint.js .",
     "checks": "node ./node_modules/eslint/bin/eslint.js . && mocha",
     "listAuthServers": "node ./scripts/list-auth-servers.js",
-    "saveCreds": "node ./scripts/add-client-credentials.js"
+    "saveCreds": "node ./scripts/add-client-credentials.js",
+    "updateAuthServersAndOpenIds": "node ./scripts/update-auth-server-and-open-id-configs"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-auth-server-and-open-id-configs.js
+++ b/scripts/update-auth-server-and-open-id-configs.js
@@ -1,0 +1,15 @@
+const { updateOpenIdConfigs } = require('../app/authorisation-servers');
+const { fetchOBAccountPaymentServiceProviders } = require('../app/ob-directory');
+
+const cacheLatestConfigs = async () => {
+  await fetchOBAccountPaymentServiceProviders();
+  await updateOpenIdConfigs();
+};
+
+cacheLatestConfigs().then(() => {
+  if (process.env.NODE_ENV !== 'test') {
+    process.exit();
+  }
+});
+
+exports.cacheLatestConfigs = cacheLatestConfigs;

--- a/test/scripts/update-auth-server-and-open-id-configs.test.js
+++ b/test/scripts/update-auth-server-and-open-id-configs.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert'); // eslint-disable-line
+const proxyquire = require('proxyquire'); // eslint-disable-line
+const sinon = require('sinon'); //eslint-disable-line
+
+describe('cacheLatestConfigs', () => {
+  let fakeFetchOBAccountPaymentServiceProviders;
+  let fakeUpdateOpenIdConfigs;
+
+  beforeEach(async () => {
+    fakeFetchOBAccountPaymentServiceProviders = sinon.stub().returns([]);
+    fakeUpdateOpenIdConfigs = sinon.stub().returns(null);
+    const cacheLatestConfigs = proxyquire('../../scripts/update-auth-server-and-open-id-configs', // eslint-disable-line
+      {
+        '../app/authorisation-servers': {
+          updateOpenIdConfigs: fakeUpdateOpenIdConfigs
+        },
+        '../app/ob-directory': {
+          fetchOBAccountPaymentServiceProviders: fakeFetchOBAccountPaymentServiceProviders
+        }
+      },
+    ).cacheLatestConfigs;
+
+    cacheLatestConfigs();
+  });
+
+  it('fetches OB account service providers', () => {
+    assert(fakeFetchOBAccountPaymentServiceProviders.called);
+  });
+
+  it('updates id configs', () => {
+    assert(fakeUpdateOpenIdConfigs.called);
+  });
+});

--- a/test/scripts/update-auth-server-and-open-id-configs.test.js
+++ b/test/scripts/update-auth-server-and-open-id-configs.test.js
@@ -12,11 +12,11 @@ describe('cacheLatestConfigs', () => {
     const cacheLatestConfigs = proxyquire('../../scripts/update-auth-server-and-open-id-configs', // eslint-disable-line
       {
         '../app/authorisation-servers': {
-          updateOpenIdConfigs: fakeUpdateOpenIdConfigs
+          updateOpenIdConfigs: fakeUpdateOpenIdConfigs,
         },
         '../app/ob-directory': {
-          fetchOBAccountPaymentServiceProviders: fakeFetchOBAccountPaymentServiceProviders
-        }
+          fetchOBAccountPaymentServiceProviders: fakeFetchOBAccountPaymentServiceProviders,
+        },
       },
     ).cacheLatestConfigs;
 


### PR DESCRIPTION
This moves caching of Auth server and OpenId configs logic to a standalone script.

* Added script.
* Added spec.
* Updated `package.json` to include new script.
* Updated `README` to include new script details.