### PR TITLE
Various fixes to JWS claims and resource server URI

### DIFF
--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -36,9 +36,9 @@ const accountRequestAuthoriseConsent = async (req, res) => {
     const signature = createJsonWebSignature(payload);
     const uri =
       `${authServerEndpoint}?${qs.stringify({
-        redirect_url: registeredRedirectUrl,
+        redirect_uri: registeredRedirectUrl,
         state,
-        clientId,
+        client_id: clientId,
         response_type: 'code',
         request: signature,
         scope,

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -79,6 +79,9 @@ const allAuthorisationServers = async () => {
 
 const fetchAndStoreOpenIdConfig = async (id, openidConfigUrl) => {
   try {
+    if (openidConfigUrl === 'https://redirect.openbanking.org.uk') {
+      return null; // ignore
+    }
     const openidConfig = await getOpenIdConfig(openidConfigUrl);
     const authServer = await getAuthServerConfig(id);
     authServer.openIdConfig = openidConfig;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -84,8 +84,9 @@ const fetchAndStoreOpenIdConfig = async (id, openidConfigUrl) => {
     authServer.openIdConfig = openidConfig;
     await setAuthServerConfig(id, authServer);
   } catch (err) {
-    error(err);
+    error(`Error getting ${openidConfigUrl} : ${err.message}`);
   }
+  return null;
 };
 
 const updateClientCredentials = async (id, clientCredentials) => {

--- a/app/authorise/request-jws.js
+++ b/app/authorise/request-jws.js
@@ -3,21 +3,21 @@ const { URL } = require('url');
 const debug = require('debug')('debug');
 
 /**
- * Audience that the ID token is intended for.
+ * Issuer of the token.
  * OpenID Connect protocol mandates this MUST include the client ID of the TPP.
  * Should contain the ClientID of the TPP’s OAuth Client.
  * Required as per FAPI RW / OpenID Standard.
  * For now return raw clientId
  */
-const audience = clientId => clientId;
+const issuer = clientId => clientId;
 
 /**
- * Issuer of the token.
- * Represents the issuer identifier of the authorization server as defined in RFC7519.
+ * Audience that the ID token is intended for.
+ * Represents the identifier of the authorization server as defined in RFC7519.
  * When a pure OAuth 2.0 is used, the value is the redirection URI.
  * When OpenID Connect is used, the value is the issuer value of the authorization server.
  */
-const issuer = (authorisationEndpoint, useOpenidConnect) => {
+const audience = (authorisationEndpoint, useOpenidConnect) => {
   debug(`authorisationEndpoint: ${authorisationEndpoint}`);
   const { origin } = new URL(authorisationEndpoint);
   const issuerValue = `${origin}/`; // todo: confirm this is correct
@@ -56,8 +56,8 @@ const createClaims = (
   scope, accountRequestId, clientId, authorisationEndpoint,
   registeredRedirectUrl, state, useOpenidConnect,
 ) => ({
-  aud: audience(clientId),
-  iss: issuer(authorisationEndpoint, useOpenidConnect),
+  aud: audience(authorisationEndpoint, useOpenidConnect),
+  iss: issuer(clientId),
   response_type: 'code id_token',
   client_id: clientId,
   redirect_uri: registeredRedirectUrl,

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -9,6 +9,9 @@ const debug = require('debug')('debug');
 const resourceServerPath = async (authorisationServerId) => {
   if (authorisationServerId) {
     const host = await resourceServerHost(authorisationServerId);
+    if (host.indexOf('/open-banking/') > 0) {
+      return host;
+    }
     const apiVersion = 'v1.1';
     return `${host}/open-banking/${apiVersion}`;
   }

--- a/test/account-request-authorise-consent.test.js
+++ b/test/account-request-authorise-consent.test.js
@@ -54,8 +54,8 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
 
   const expectedRedirectHost = 'http://example.com/authorize';
   const expectedParams = {
-    clientId,
-    redirect_url: redirectUrl,
+    client_id: clientId,
+    redirect_uri: redirectUrl,
     request: jsonWebSignature,
     response_type: 'code',
     scope: 'openid accounts',

--- a/test/authorise/request-jws.test.js
+++ b/test/authorise/request-jws.test.js
@@ -13,9 +13,9 @@ describe('createClaims', () => {
   const sessionId = 'testSessionId';
   const state = statePayload(authorisationServerId, sessionId);
 
-  const expectedClaims = issuer => ({
-    aud: clientId,
-    iss: issuer,
+  const expectedClaims = audience => ({
+    aud: audience,
+    iss: clientId,
     response_type: 'code id_token',
     client_id: clientId,
     redirect_uri: registeredRedirectUrl,


### PR DESCRIPTION
- Add `/open-banking` prefix to resource URL only when needed.
- Some authorisation server configs already have `/opening-banking/v1.1` prefix on `BaseDNSUri` field.
- Fix claim field names to `request_uri` and `client_id`.
- Correct values for `aud` and `iss` in JWS claims.
- Set `aud` and `iss` from perspective of TPP client.
- Hardcode ignoring of OB Directory test `openidConfigUrl`.