### PR TITLE
Fix and improve account request response handling

### DIFF
--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -53,10 +53,22 @@ const createAccessToken = async (authorisationServerId) => {
 const createAccountRequest = async (authorisationServerId, accessToken, fapiFinancialId) => {
   const resourcePath = await resourceServerPath(authorisationServerId);
   const response = await postAccountRequests(resourcePath, accessToken, fapiFinancialId);
-  if (response.Data && response.Data.Status === 'AwaitingAuthorisation') {
-    return response.Data.AccountRequestId;
+  let error;
+  if (response.Data) {
+    const status = response.Data.Status;
+    if (status === 'AwaitingAuthorisation' || status === 'Authorised') {
+      if (response.Data.AccountRequestId) {
+        return response.Data.AccountRequestId;
+      }
+    } else {
+      error = new Error(`account request response status: "${status}"`);
+      error.status = 500;
+      throw error;
+    }
   }
-  return null;
+  error = new Error('Account request response missing payload');
+  error.status = 500;
+  throw error;
 };
 
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -53,8 +53,8 @@ const createAccessToken = async (authorisationServerId) => {
 const createAccountRequest = async (authorisationServerId, accessToken, fapiFinancialId) => {
   const resourcePath = await resourceServerPath(authorisationServerId);
   const response = await postAccountRequests(resourcePath, accessToken, fapiFinancialId);
-  if (response.Data && response.Status === 'AwaitingAuthorisation') {
-    return response.AccountRequestId;
+  if (response.Data && response.Data.Status === 'AwaitingAuthorisation') {
+    return response.Data.AccountRequestId;
   }
   return null;
 };

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -48,9 +48,9 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   const tokenResponse = { access_token: accessToken };
   const accountRequestsResponse = status => ({
     Data: {
+      AccountRequestId: accountRequestId,
+      Status: status,
     },
-    AccountRequestId: accountRequestId,
-    Status: status,
   });
 
   const setup = status => () => {

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -55,7 +55,11 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
   const setup = status => () => {
     tokenStub = sinon.stub().returns(tokenResponse);
-    accountRequestsStub = sinon.stub().returns(accountRequestsResponse(status));
+    if (status) {
+      accountRequestsStub = sinon.stub().returns(accountRequestsResponse(status));
+    } else {
+      accountRequestsStub = sinon.stub().returns({});
+    }
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
     resourceServerHostStub = sinon.stub().returns(resourceServer);
     setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
@@ -84,12 +88,57 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     });
   });
 
+  describe('when Authorised', () => {
+    before(setup('Authorised'));
+
+    it('returns accountRequestId from postAccountRequests call', async () => {
+      const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+      assert.equal(id, accountRequestId);
+    });
+  });
+
   describe('when Rejected', () => {
     before(setup('Rejected'));
 
-    it('returns null', async () => {
-      const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
-      assert.equal(id, null);
+    it('throws error for now', async () => {
+      try {
+        await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+        assert.ok(false);
+      } catch (err) {
+        if (err.code && err.code === 'ERR_ASSERTION') throw err;
+        assert.equal(err.message, 'account request response status: "Rejected"');
+        assert.equal(err.status, 500);
+      }
+    });
+  });
+
+  describe('when Revoked', () => {
+    before(setup('Revoked'));
+
+    it('throws error for now', async () => {
+      try {
+        await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+        assert.ok(false);
+      } catch (err) {
+        if (err.code && err.code === 'ERR_ASSERTION') throw err;
+        assert.equal(err.message, 'account request response status: "Revoked"');
+        assert.equal(err.status, 500);
+      }
+    });
+  });
+
+  describe('when AccountRequestId not found in payload', () => {
+    before(setup(null));
+
+    it('throws error', async () => {
+      try {
+        await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+        assert.ok(false);
+      } catch (err) {
+        if (err.code && err.code === 'ERR_ASSERTION') throw err;
+        assert.equal(err.message, 'Account request response missing payload');
+        assert.equal(err.status, 500);
+      }
     });
   });
 });


### PR DESCRIPTION
- Pick up `AccountRequestId` from correct location in response payload.
- Throw error when account request response `Status` is `Rejected` or `Revoked`.
- Throw error when account request response `Status` or `AccountRequestId` not found in payload.