### PR TITLE
Change account request response status to 200

### DIFF
--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -45,7 +45,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
         scope,
       })}`;
     debug(`authorize URL is: ${uri}`);
-    return res.send(201, { uri }); // We can't intercept a 302 !
+    return res.send(200, { uri }); // We can't intercept a 302 !
   } catch (err) {
     error(err);
     const status = err.status ? err.status : 500;

--- a/app/account-request-authorise-consent.js
+++ b/app/account-request-authorise-consent.js
@@ -45,7 +45,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
         scope,
       })}`;
     debug(`authorize URL is: ${uri}`);
-    return res.redirect(302, uri);
+    return res.send(201, { uri }); // We can't intercept a 302 !
   } catch (err) {
     error(err);
     const status = err.status ? err.status : 500;

--- a/test/account-request-authorise-consent.test.js
+++ b/test/account-request-authorise-consent.test.js
@@ -65,10 +65,10 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
     state: 'eyJhdXRob3Jpc2F0aW9uU2VydmVySWQiOiIxMjMifQ==',
   };
 
-  it('creates a redirect URI with a 201 code via the to /authorize endpoint', (done) => {
+  it('creates a redirect URI with a 200 code via the to /authorize endpoint', (done) => {
     doPost(app)
       .end((e, r) => {
-        assert.equal(r.status, 201);
+        assert.equal(r.status, 200);
         const location = r.body.uri;
         const parts = location.split('?');
         const host = parts[0];

--- a/test/account-request-authorise-consent.test.js
+++ b/test/account-request-authorise-consent.test.js
@@ -65,11 +65,11 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
     state: 'eyJhdXRob3Jpc2F0aW9uU2VydmVySWQiOiIxMjMifQ==',
   };
 
-  it('returns 302 redirect to /authorize endpoint', (done) => {
+  it('creates a redirect URI with a 201 code via the to /authorize endpoint', (done) => {
     doPost(app)
       .end((e, r) => {
-        assert.equal(r.status, 302);
-        const { location } = r.headers;
+        assert.equal(r.status, 201);
+        const location = r.body.uri;
         const parts = location.split('?');
         const host = parts[0];
         const params = qs.parse(parts[1]);


### PR DESCRIPTION
- Change response status from `302` to `200` for successful `/account-request-authorise-consent` response.
- As in browser we can't intercept a `302` response.
- This requires corresponding change be merged on `tpp-reference-client`: https://github.com/OpenBankingUK/tpp-reference-client/pull/31