### PR TITLE
Store access token response under session ID

### DIFF
--- a/app/authorisation-code-granted.js
+++ b/app/authorisation-code-granted.js
@@ -1,6 +1,8 @@
 const env = require('env-var');
+const { setTokenPayload } = require('./authorise');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('./authorisation-servers');
+const debug = require('debug')('debug');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
 
@@ -9,13 +11,20 @@ const handler = async (req, res) => {
   try {
     const { authorisationServerId, code } = req.query;
     const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
-    const accessTokenPayload = {
+    const accessTokenRequest = {
       grant_type: 'authorization_code',
       redirect_uri: redirectionUrl,
       code,
     };
 
-    await postToken(authorisationServerId, clientId, clientSecret, accessTokenPayload);
+    const tokenPayload = await postToken(
+      authorisationServerId, clientId,
+      clientSecret, accessTokenRequest,
+    );
+    const sessionId = req.headers.authorization;
+    debug(`sessionId: ${sessionId}`);
+    debug(`tokenPayload: ${JSON.stringify(tokenPayload)}`);
+    await setTokenPayload(sessionId, tokenPayload);
     return res.status(204).send();
   } catch (err) {
     const status = err.status ? err.status : 500;

--- a/app/authorise/access-tokens.js
+++ b/app/authorise/access-tokens.js
@@ -1,0 +1,25 @@
+const { get, set } = require('../storage');
+const debug = require('debug')('debug');
+
+const ACCESS_TOKENS_COLLECTION = 'accessTokens';
+
+const tokenPayload = async sessionId => get(ACCESS_TOKENS_COLLECTION, sessionId);
+
+const setTokenPayload = async (sessionId, payload) =>
+  set(ACCESS_TOKENS_COLLECTION, payload, sessionId);
+
+const accessToken = async (sessionId) => {
+  const payload = await tokenPayload(sessionId);
+  debug(`accessToken#sessionId: ${sessionId}`);
+  debug(`accessToken#payload: ${JSON.stringify(payload)}`);
+  if (payload && payload.access_token) {
+    return payload.access_token;
+  }
+  const err = new Error(`access token for session ${sessionId} not found`);
+  err.status = 500;
+  throw err;
+};
+
+exports.setTokenPayload = setTokenPayload;
+exports.accessToken = accessToken;
+exports.ACCESS_TOKENS_COLLECTION = ACCESS_TOKENS_COLLECTION;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,4 +1,7 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
+const { setTokenPayload, accessToken } = require('./access-tokens');
 
+exports.accessToken = accessToken;
 exports.createClaims = createClaims;
 exports.createJsonWebSignature = createJsonWebSignature;
+exports.setTokenPayload = setTokenPayload;

--- a/app/index.js
+++ b/app/index.js
@@ -34,6 +34,7 @@ app.use(
 app.all('/account-request-authorise-consent', requireAuthorization);
 app.post('/account-request-authorise-consent', accountRequestAuthoriseConsent);
 
+app.all('/tpp/authorized', requireAuthorization);
 app.get('/tpp/authorized', authorisationCodeGrantedHandler);
 
 app.all('/open-banking/*', requireAuthorization);

--- a/test/authorisation-code-granted.test.js
+++ b/test/authorisation-code-granted.test.js
@@ -10,22 +10,30 @@ const clientSecret = 'secret';
 const authorisationServerId = '123';
 const accessToken = 'access-token';
 const authorisationCode = '12345_67xxx';
+const sessionId = 'testSession';
 
-const tokenPayload = {
+const tokenRequestPayload = {
   grant_type: 'authorization_code', // eslint-disable-line quote-props
   code: authorisationCode,
   redirect_uri: redirectionUrl, // eslint-disable-line quote-props
 };
 
+const tokenResponsePayload = {
+  access_token: accessToken,
+  expires_in: 3600,
+};
+
 describe('Authorized Code Granted', () => {
   let redirection;
   let postTokenStub;
+  let setTokenPayloadStub;
   let getClientCredentialsStub;
   let request;
   let response;
 
   beforeEach(() => {
-    postTokenStub = sinon.stub().returns({ access_token: accessToken });
+    setTokenPayloadStub = sinon.stub();
+    postTokenStub = sinon.stub().returns(tokenResponsePayload);
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
     redirection = proxyquire('../app/authorisation-code-granted.js', {
       'env-var': env.mock({
@@ -35,11 +43,15 @@ describe('Authorized Code Granted', () => {
       './authorisation-servers': {
         getClientCredentials: getClientCredentialsStub,
       },
+      './authorise': { setTokenPayload: setTokenPayloadStub },
     });
 
     request = httpMocks.createRequest({
       method: 'GET',
       url: '/tpp/authorized',
+      headers: {
+        authorization: sessionId,
+      },
       query: {
         code: authorisationCode,
         authorisationServerId,
@@ -58,12 +70,13 @@ describe('Authorized Code Granted', () => {
       assert.equal(response.statusCode, 204);
     });
 
-    it('calls postToken to obtain an access token', async () => {
+    it('calls postToken to obtain and store an access token', async () => {
       await redirection.authorisationCodeGrantedHandler(request, response);
       assert(postTokenStub.calledWithExactly(
         authorisationServerId,
-        clientId, clientSecret, tokenPayload,
+        clientId, clientSecret, tokenRequestPayload,
       ));
+      assert(setTokenPayloadStub.calledWithExactly(sessionId, tokenResponsePayload));
     });
 
     describe('error handling', () => {

--- a/test/authorise/access-tokens.test.js
+++ b/test/authorise/access-tokens.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+const { accessToken, setTokenPayload } = require('../../app/authorise');
+const { ACCESS_TOKENS_COLLECTION } = require('../../app/authorise/access-tokens');
+
+const { drop } = require('../../app/storage.js');
+
+const sessionId = 'testSession';
+const token = 'testAccessToken';
+const tokenPayload = {
+  access_token: token,
+  expires_in: 3600,
+};
+
+describe('setTokenPayload', () => {
+  beforeEach(async () => {
+    await drop(ACCESS_TOKENS_COLLECTION);
+  });
+
+  afterEach(async () => {
+    await drop(ACCESS_TOKENS_COLLECTION);
+  });
+
+  it('stores payload and allows accessToken to be retrieved', async () => {
+    await setTokenPayload(sessionId, tokenPayload);
+    assert.equal(await accessToken(sessionId), token);
+  });
+});


### PR DESCRIPTION
Store token payload from authorisation code request under session ID in mongodb.

For now there is no flushing of expired tokens. Can be added later.