### PR TITLE
Make setup request logic generic for reuse by payments

### DIFF
--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,57 +1,7 @@
-const { postToken } = require('../obtain-access-token');
+const { makeRequest } = require('../setup-request');
 const { postAccountRequests } = require('./account-requests');
-const {
-  getClientCredentials,
-  resourceServerHost,
-} = require('../authorisation-servers');
 
-const resourceServerPath = async (authorisationServerId) => {
-  if (authorisationServerId) {
-    const host = await resourceServerHost(authorisationServerId);
-    if (host.indexOf('/open-banking/') > 0) {
-      return host;
-    }
-    const apiVersion = 'v1.1';
-    return `${host}/open-banking/${apiVersion}`;
-  }
-  return null;
-};
-
-const validateParameters = (authorisationServerId, fapiFinancialId) => {
-  let error;
-  if (!fapiFinancialId) {
-    error = new Error('fapiFinancialId missing from request payload');
-    error.status = 400;
-  }
-  if (!authorisationServerId) {
-    error = new Error('authorisationServerId missing from request payload');
-    error.status = 400;
-  }
-  if (error) {
-    throw error;
-  }
-};
-
-// Returns access-token when request successful
-const createAccessToken = async (authorisationServerId) => {
-  const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
-  const accessTokenPayload = {
-    scope: 'accounts',
-    grant_type: 'client_credentials',
-  };
-
-  const response = await postToken(
-    authorisationServerId,
-    clientId,
-    clientSecret,
-    accessTokenPayload,
-  );
-  return response.access_token;
-};
-
-// Returns accountRequestId when request successful
-const createAccountRequest = async (authorisationServerId, accessToken, fapiFinancialId) => {
-  const resourcePath = await resourceServerPath(authorisationServerId);
+const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
   const response = await postAccountRequests(resourcePath, accessToken, fapiFinancialId);
   let error;
   if (response.Data) {
@@ -61,7 +11,7 @@ const createAccountRequest = async (authorisationServerId, accessToken, fapiFina
         return response.Data.AccountRequestId;
       }
     } else {
-      error = new Error(`account request response status: "${status}"`);
+      error = new Error(`Account request response status: "${status}"`);
       error.status = 500;
       throw error;
     }
@@ -72,12 +22,10 @@ const createAccountRequest = async (authorisationServerId, accessToken, fapiFina
 };
 
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
-  validateParameters(authorisationServerId, fapiFinancialId);
-  const accessToken = await createAccessToken(authorisationServerId);
-  const accountRequestId = await createAccountRequest(
+  const accountRequestId = await makeRequest(
     authorisationServerId,
-    accessToken,
     fapiFinancialId,
+    createRequest,
   );
   return accountRequestId;
 };

--- a/app/setup-request/index.js
+++ b/app/setup-request/index.js
@@ -1,0 +1,3 @@
+const { makeRequest } = require('./setup-request');
+
+exports.makeRequest = makeRequest;

--- a/app/setup-request/setup-request.js
+++ b/app/setup-request/setup-request.js
@@ -1,0 +1,63 @@
+const { postToken } = require('../obtain-access-token');
+const {
+  getClientCredentials,
+  resourceServerHost,
+} = require('../authorisation-servers');
+
+const resourceServerPath = async (authorisationServerId) => {
+  if (authorisationServerId) {
+    const host = await resourceServerHost(authorisationServerId);
+    if (host.indexOf('/open-banking/') > 0) {
+      return host;
+    }
+    const apiVersion = 'v1.1';
+    return `${host}/open-banking/${apiVersion}`;
+  }
+  return null;
+};
+
+const validateParameters = (authorisationServerId, fapiFinancialId) => {
+  let error;
+  if (!fapiFinancialId) {
+    error = new Error('fapiFinancialId missing from request payload');
+    error.status = 400;
+  }
+  if (!authorisationServerId) {
+    error = new Error('authorisationServerId missing from request payload');
+    error.status = 400;
+  }
+  if (error) {
+    throw error;
+  }
+};
+
+// Returns access-token when request successful
+const createAccessToken = async (authorisationServerId) => {
+  const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
+  const accessTokenPayload = {
+    scope: 'accounts payments', // include both scopes for client credentials grant
+    grant_type: 'client_credentials',
+  };
+
+  const response = await postToken(
+    authorisationServerId,
+    clientId,
+    clientSecret,
+    accessTokenPayload,
+  );
+  return response.access_token;
+};
+
+const makeRequest = async (authorisationServerId, fapiFinancialId, createRequestFn) => {
+  validateParameters(authorisationServerId, fapiFinancialId);
+  const accessToken = await createAccessToken(authorisationServerId);
+  const resourcePath = await resourceServerPath(authorisationServerId);
+  const requestId = await createRequestFn(
+    resourcePath,
+    accessToken,
+    fapiFinancialId,
+  );
+  return requestId;
+};
+
+exports.makeRequest = makeRequest;

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -36,11 +36,12 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   const clientId = 'id';
   const clientSecret = 'secret';
   const tokenPayload = {
-    scope: 'accounts',
+    scope: 'accounts payments',
     grant_type: 'client_credentials',
   };
   const accountRequestId = '88379';
   let setupAccountRequestProxy;
+  let makeRequestProxy;
   let tokenStub;
   let accountRequestsStub;
   let getClientCredentialsStub;
@@ -62,13 +63,16 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     }
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
     resourceServerHostStub = sinon.stub().returns(resourceServer);
-    setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
+    makeRequestProxy = proxyquire('../../app/setup-request/setup-request', {
       '../obtain-access-token': { postToken: tokenStub },
-      './account-requests': { postAccountRequests: accountRequestsStub },
       '../authorisation-servers': {
         getClientCredentials: getClientCredentialsStub,
         resourceServerHost: resourceServerHostStub,
       },
+    }).makeRequest;
+    setupAccountRequestProxy = proxyquire('../../app/setup-account-request/setup-account-request', {
+      '../setup-request': { makeRequest: makeRequestProxy },
+      './account-requests': { postAccountRequests: accountRequestsStub },
     }).setupAccountRequest;
   };
 
@@ -106,7 +110,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
         assert.ok(false);
       } catch (err) {
         if (err.code && err.code === 'ERR_ASSERTION') throw err;
-        assert.equal(err.message, 'account request response status: "Rejected"');
+        assert.equal(err.message, 'Account request response status: "Rejected"');
         assert.equal(err.status, 500);
       }
     });
@@ -121,7 +125,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
         assert.ok(false);
       } catch (err) {
         if (err.code && err.code === 'ERR_ASSERTION') throw err;
-        assert.equal(err.message, 'account request response status: "Revoked"');
+        assert.equal(err.message, 'Account request response status: "Revoked"');
         assert.equal(err.status, 500);
       }
     });


### PR DESCRIPTION
- Refactor generic setup request logic into `app/setup-request/setup-request.js`.
- Pass `createRequestFn` as parameter to new generic `makeRequest` function.
- Set scopes to `accounts payments` for `client_credentials` grant.
- Intention is this code be reused for payments request.