### PR TITLE
Lookup fapiFinancialId REFAPP-142

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ DEBUG=error,log \
 * Set OB Provisioned status using `OB_PROVISIONED` env var.
 * Set OB Directory host using `OB_DIRECTORY_HOST` env var.
 * Set OB Directory access_token using `OB_DIRECTORY_ACCESS_TOKEN` env var.
-* Set hardcoded x-fapi-financial-id using `X_FAPI_FINANCIAL_ID` env var.
 * Set the environment variables `REDIS_PORT` and `REDIS_HOST` as per your redis instance.
 Set the environment variables `MONGODB_URI` as per your mongodb instance.
 

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -44,10 +44,30 @@ const getClientCredentials = async (authServerId) => {
   throw err;
 };
 
+const obDirectoryConfig = async (id) => {
+  try {
+    const config = await getAuthServerConfig(id);
+    return (config && config.obDirectoryConfig) ? config.obDirectoryConfig : null;
+  } catch (err) {
+    error(err);
+    return null;
+  }
+};
+
+const fapiFinancialIdFor = async (authServerId) => {
+  const config = await obDirectoryConfig(authServerId);
+  if (config && config.OBOrganisationId) {
+    return config.OBOrganisationId;
+  }
+  const err = new Error(`fapiFinancialId for ${authServerId} not found`);
+  err.status = 500;
+  throw err;
+};
+
 const resourceServerHost = async (authServerId) => {
-  const authServer = await getAuthServerConfig(authServerId);
-  if (authServer && authServer.obDirectoryConfig && authServer.obDirectoryConfig.BaseApiDNSUri) {
-    return authServer.obDirectoryConfig.BaseApiDNSUri;
+  const config = await obDirectoryConfig(authServerId);
+  if (config && config.BaseApiDNSUri) {
+    return config.BaseApiDNSUri;
   }
   const err = new Error(`resource server host for ${authServerId} not found`);
   err.status = 500;
@@ -182,4 +202,5 @@ exports.updateOpenIdConfigs = updateOpenIdConfigs;
 exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;
 exports.setAuthServerConfig = setAuthServerConfig;
+exports.fapiFinancialIdFor = fapiFinancialIdFor;
 exports.ASPSP_AUTH_SERVERS_COLLECTION = ASPSP_AUTH_SERVERS_COLLECTION;

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -2,6 +2,7 @@ const {
   allAuthorisationServers,
   authorisationEndpoint,
   issuer,
+  fapiFinancialIdFor,
   authorisationServersForClient,
   storeAuthorisationServers,
   tokenEndpoint,
@@ -15,6 +16,7 @@ exports.allAuthorisationServers = allAuthorisationServers;
 exports.authorisationServersForClient = authorisationServersForClient;
 exports.authorisationEndpoint = authorisationEndpoint;
 exports.issuer = issuer;
+exports.fapiFinancialIdFor = fapiFinancialIdFor;
 exports.storeAuthorisationServers = storeAuthorisationServers;
 exports.tokenEndpoint = tokenEndpoint;
 exports.resourceServerHost = resourceServerHost;

--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -3,13 +3,15 @@ const { setupMutualTLS } = require('../certs-util');
 const { resourceServerHost } = require('../authorisation-servers');
 const { URL } = require('url');
 const { accessToken } = require('../authorise');
+const { fapiFinancialIdFor } = require('../authorisation-servers');
 const debug = require('debug')('debug');
 const error = require('debug')('error');
 
 const resourceRequestHandler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   const authServerId = req.headers['x-authorization-server-id'];
-  const xFapiFinancialId = req.headers['x-fapi-financial-id'];
+  const xFapiFinancialId = fapiFinancialIdFor(authServerId);
+
   const sessionId = req.headers.authorization;
   let host;
   try {

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -1,5 +1,7 @@
 const { setupAccountRequest } = require('./setup-account-request');
 const { generateRedirectUri } = require('../authorise');
+const { fapiFinancialIdFor } = require('../authorisation-servers');
+
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -9,7 +11,8 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   try {
     const sessionId = req.headers['authorization'];
     const { authorisationServerId } = req.body;
-    const fapiFinancialId = req.headers['x-fapi-financial-id'];
+    const fapiFinancialId = fapiFinancialIdFor(authorisationServerId);
+
     debug(`authorisationServerId: ${authorisationServerId}`);
     const accountRequestId = await setupAccountRequest(authorisationServerId, fapiFinancialId);
     const interactionId = uuidv4();

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -1,5 +1,6 @@
 const { setupPayment } = require('./setup-payment');
 const { generateRedirectUri } = require('../authorise');
+const { fapiFinancialIdFor } = require('../authorisation-servers');
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -11,7 +12,7 @@ const paymentAuthoriseConsent = async (req, res) => {
     const { authorisationServerId } = req.body;
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;
-    const fapiFinancialId = req.headers['x-fapi-financial-id'];
+    const fapiFinancialId = fapiFinancialIdFor(authorisationServerId);
     debug(`authorisationServerId: ${authorisationServerId}`);
     const idempotencyKey = uuidv4();
     const interactionId = uuidv4();

--- a/app/setup-payment/payment-submission.js
+++ b/app/setup-payment/payment-submission.js
@@ -1,4 +1,5 @@
 const { submitPayment } = require('./submit-payment');
+const { fapiFinancialIdFor } = require('../authorisation-servers');
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -6,9 +7,9 @@ const debug = require('debug')('debug');
 const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const fapiFinancialId = req.headers['x-fapi-financial-id'];
-    const fapiInteractionId = req.headers['x-fapi-interaction-id'];
     const authServerId = req.headers['x-authorization-server-id'];
+    const fapiFinancialId = fapiFinancialIdFor(authServerId);
+    const fapiInteractionId = req.headers['x-fapi-interaction-id'];
     const idempotencyKey = uuidv4();
 
     const paymentSubmissionId = await submitPayment(

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -11,18 +11,20 @@ const {
   updateOpenIdConfigs,
   getClientCredentials,
   updateClientCredentials,
+  fapiFinancialIdFor,
 } = require('../../app/authorisation-servers');
 
 const nock = require('nock');
 
 const authServerId = 'aaaj4NmBD8lQxmLh2O9FLY';
+const orgId = 'aaa-example-org';
 const flattenedObDirectoryAuthServerList = [
   {
     Id: authServerId,
     BaseApiDNSUri: 'http://aaa.example.com',
     CustomerFriendlyName: 'AAA Example Bank',
     OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
-    OBOrganisationId: 'aaa-example-org',
+    OBOrganisationId: orgId,
   },
 ];
 
@@ -70,6 +72,22 @@ describe('authorisation servers', () => {
 
   afterEach(async () => {
     await drop(ASPSP_AUTH_SERVERS_COLLECTION);
+  });
+
+  describe('fapiFinancialIdFor', () => {
+    it('returns fapiFinancialId given valid authServerId', async () => {
+      const id = await fapiFinancialIdFor(authServerId);
+      assert.equal(id, orgId);
+    });
+
+    it('throws error given invalid authServerId', async () => {
+      try {
+        await fapiFinancialIdFor('invalid-id');
+        assert.ok(false);
+      } catch (err) {
+        assert.equal(err.status, 500);
+      }
+    });
   });
 
   describe('getClientCredentials', () => {

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -17,6 +17,7 @@ const issuer = 'http://example.com';
 const jsonWebSignature = 'testSignedPayload';
 const key = 'testKey';
 const interactionId = key;
+const fapiFinancialId = 'testFapiFinancialId';
 
 const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
   const clientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
@@ -48,6 +49,9 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
       '../authorise': {
         generateRedirectUri,
       },
+      '../authorisation-servers': {
+        fapiFinancialIdFor: () => fapiFinancialId,
+      },
       'uuid/v4': keyStub,
     },
   );
@@ -57,7 +61,6 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
   return app;
 };
 
-const fapiFinancialId = 'testFapiFinancialId';
 const sessionId = 'testSession';
 
 const doPost = app => request(app)

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -65,7 +65,6 @@ const sessionId = 'testSession';
 
 const doPost = app => request(app)
   .post('/account-request-authorise-consent')
-  .set('x-fapi-financial-id', fapiFinancialId)
   .set('authorization', sessionId)
   .send({ authorisationServerId });
 

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -17,6 +17,7 @@ const issuer = 'http://example.com';
 const jsonWebSignature = 'testSignedPayload';
 const key = 'testKey';
 const interactionId = key;
+const fapiFinancialId = 'testFapiFinancialId';
 
 const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
   const clientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
@@ -48,6 +49,9 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
       '../authorise': {
         generateRedirectUri,
       },
+      '../authorisation-servers': {
+        fapiFinancialIdFor: () => fapiFinancialId,
+      },
       'uuid/v4': keyStub,
     },
   );
@@ -57,7 +61,6 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
   return app;
 };
 
-const fapiFinancialId = 'testFapiFinancialId';
 const sessionId = 'testSession';
 
 const doPost = app => request(app)

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -65,7 +65,6 @@ const sessionId = 'testSession';
 
 const doPost = app => request(app)
   .post('/payment-authorise-consent')
-  .set('x-fapi-financial-id', fapiFinancialId)
   .set('authorization', sessionId)
   .send({ authorisationServerId });
 

--- a/test/setup-payment/payment-submission.test.js
+++ b/test/setup-payment/payment-submission.test.js
@@ -6,6 +6,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 
 const fapiFinancialId = 'testFapiFinancialId';
+const authServerId = 'testAuthServerId';
 
 const setupApp = (submitPaymentStub) => {
   const { paymentSubmission } = proxyquire(
@@ -30,7 +31,7 @@ const PAYMENT_SUBMISSION_ID = 'PS456';
 
 const doPost = app => request(app)
   .post('/payment-submissions')
-  .set('x-fapi-financial-id', fapiFinancialId)
+  .set('x-authorization-server-id', authServerId)
   .set('x-fapi-interaction-id', fapiInteractionId)
   .send();
 

--- a/test/setup-payment/payment-submission.test.js
+++ b/test/setup-payment/payment-submission.test.js
@@ -5,12 +5,17 @@ const sinon = require('sinon');
 const express = require('express');
 const bodyParser = require('body-parser');
 
+const fapiFinancialId = 'testFapiFinancialId';
+
 const setupApp = (submitPaymentStub) => {
   const { paymentSubmission } = proxyquire(
     '../../app/setup-payment/payment-submission.js',
     {
       './submit-payment': {
         submitPayment: submitPaymentStub,
+      },
+      '../authorisation-servers': {
+        fapiFinancialIdFor: () => fapiFinancialId,
       },
     },
   );
@@ -20,7 +25,6 @@ const setupApp = (submitPaymentStub) => {
   return app;
 };
 
-const fapiFinancialId = 'testFapiFinancialId';
 const fapiInteractionId = 'testInteractionId';
 const PAYMENT_SUBMISSION_ID = 'PS456';
 


### PR DESCRIPTION
- When handling requests lookup `fapiFinancialId` using the `authServerId`.
- Client now no longer needs to set `x-fapi-financial-id` header.
