### PR TITLE
No longer send ASPSP orgId to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,16 @@ Here's a sample list of test ASPSPs. This is __NOT__ the raw response from the O
     "id": "aaaj4NmBD8lQxmLh2O",
     "logoUri": "",
     "name": "AAA Example Bank",
-    "orgId": "aaax5nTR33811Qy",
   },
   {
     "id": "bbbX7tUB4fPIYB0k1m",
     "logoUri": "",
     "name": "BBB Example Bank",
-    "orgId": "bbbUB4fPIYB0k1m",
   },
   {
     "id": "cccbN8iAsMh74sOXhk",
     "logoUri": "",
     "name": "CCC Example Bank",
-    "orgId": "cccMh74sOXhkQfi",
   }
 ]
 ```

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -20,12 +20,10 @@ const transformServerData = (data) => {
   const id = data.Id;
   const logoUri = data.CustomerFriendlyLogoUri;
   const name = data.CustomerFriendlyName;
-  const orgId = data.OBOrganisationId;
   return {
     id,
     logoUri,
     name,
-    orgId,
   };
 };
 

--- a/test/ob-directory.test.js
+++ b/test/ob-directory.test.js
@@ -38,19 +38,16 @@ const expectedResult = [
     id: 'aaaj4NmBD8lQxmLh2O9FLY',
     logoUri: 'string',
     name: 'AAA Example Bank',
-    orgId: 'aaax5nTR33811QyQfi',
   },
   {
     id: 'bbbX7tUB4fPIYB0k1m',
     logoUri: 'string',
     name: 'BBB Example Bank',
-    orgId: 'bbbcccUB4fPIYB0k1m',
   },
   {
     id: 'cccbN8iAsMh74sOXhk',
     logoUri: 'string',
     name: 'CCC Example Bank',
-    orgId: 'bbbcccUB4fPIYB0k1m',
   },
 ];
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -6,13 +6,12 @@ const assert = require('assert');
 
 describe('storage set data with id', () => {
   const collection = 'testAuthServers';
-  const orgId = 'bbbccc-example-org';
   const data = {
     BaseApiDNSUri: 'http://bbb.example.com',
     CustomerFriendlyLogoUri: 'string',
     CustomerFriendlyName: 'BBB Example Bank',
   };
-  const id = `${orgId}-${data.BaseApiDNSUri}`;
+  const id = 'testId';
 
   it('then get with invalid id returns null', async () => {
     await set(collection, data, id);


### PR DESCRIPTION
Client no longer needs to know about `orgId/fapiFinancialId`.