### PR TITLE
No longer pass fapiFinancialId to accessTokenAndResourcePath

### DIFF
--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -22,10 +22,7 @@ const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
 };
 
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(
-    authorisationServerId,
-    fapiFinancialId,
-  );
+  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
   const accountRequestId = await createRequest(
     resourcePath,
     accessToken,

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -12,8 +12,9 @@ const paymentAuthoriseConsent = async (req, res) => {
     const { authorisationServerId } = req.body;
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;
-    const fapiFinancialId = fapiFinancialIdFor(authorisationServerId);
+    const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
     debug(`authorisationServerId: ${authorisationServerId}`);
+    debug(`fapiFinancialId: ${fapiFinancialId}`);
     const idempotencyKey = uuidv4();
     const interactionId = uuidv4();
 

--- a/app/setup-payment/setup-payment.js
+++ b/app/setup-payment/setup-payment.js
@@ -38,10 +38,7 @@ const createRequest = async (resourcePath, accessToken, fapiFinancialId,
 
 const setupPayment = async (authorisationServerId,
   fapiFinancialId, CreditorAccount, InstructedAmount, idempotencyKey, interactionId) => {
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(
-    authorisationServerId,
-    fapiFinancialId,
-  );
+  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
 
   const paymentId = await createRequest(
     resourcePath, accessToken, fapiFinancialId,

--- a/app/setup-payment/submit-payment.js
+++ b/app/setup-payment/submit-payment.js
@@ -27,10 +27,7 @@ const makePayment = async (resourcePath, accessToken, fapiFinancialId,
 
 const submitPayment = async (authorisationServerId,
   fapiFinancialId, idempotencyKey, fapiInteractionId) => {
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(
-    authorisationServerId,
-    fapiFinancialId,
-  );
+  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
   const r =
     await retrievePaymentDetails(fapiInteractionId);
 

--- a/app/setup-request/setup-request.js
+++ b/app/setup-request/setup-request.js
@@ -16,17 +16,10 @@ const resourceServerPath = async (authorisationServerId) => {
   return null;
 };
 
-const validateParameters = (authorisationServerId, fapiFinancialId) => {
-  let error;
-  if (!fapiFinancialId) {
-    error = new Error('fapiFinancialId missing from request payload');
-    error.status = 400;
-  }
+const validateParameter = (authorisationServerId) => {
   if (!authorisationServerId) {
-    error = new Error('authorisationServerId missing from request payload');
+    const error = new Error('authorisationServerId missing from request payload');
     error.status = 400;
-  }
-  if (error) {
     throw error;
   }
 };
@@ -48,8 +41,8 @@ const createAccessToken = async (authorisationServerId) => {
   return response.access_token;
 };
 
-const accessTokenAndResourcePath = async (authorisationServerId, fapiFinancialId) => {
-  validateParameters(authorisationServerId, fapiFinancialId);
+const accessTokenAndResourcePath = async (authorisationServerId) => {
+  validateParameter(authorisationServerId);
   const accessToken = await createAccessToken(authorisationServerId);
   const resourcePath = await resourceServerPath(authorisationServerId);
   return { accessToken, resourcePath };

--- a/test/setup-request/setup-request.test.js
+++ b/test/setup-request/setup-request.test.js
@@ -5,22 +5,12 @@ const { checkErrorThrown } = require('../utils');
 const { accessTokenAndResourcePath } = require('../../app/setup-request'); // eslint-disable-line
 
 const authorisationServerId = 'testAuthorisationServerId';
-const fapiFinancialId = 'testFinancialId';
 
 describe('accessTokenAndResourcePath called with blank authorisationServerId', () => {
   it('throws error with 400 status set', async () => {
     await checkErrorThrown(
-      async () => accessTokenAndResourcePath(null, fapiFinancialId),
+      async () => accessTokenAndResourcePath(null),
       400, 'authorisationServerId missing from request payload',
-    );
-  });
-});
-
-describe('accessTokenAndResourcePath called with blank fapiFinancialId', () => {
-  it('throws error with 400 status set', async () => {
-    await checkErrorThrown(
-      async () => accessTokenAndResourcePath(authorisationServerId, null),
-      400, 'fapiFinancialId missing from request payload',
     );
   });
 });
@@ -48,7 +38,7 @@ describe('accessTokenAndResourcePath called with valid parameters', () => {
 
   it('returns accessToken and resourcePath', async () => {
     const { accessToken, resourcePath } =
-      await accessTokenAndResourcePathProxy(authorisationServerId, fapiFinancialId);
+      await accessTokenAndResourcePathProxy(authorisationServerId);
     assert(tokenStub.calledWithExactly(
       authorisationServerId,
       clientId, clientSecret, tokenPayload,


### PR DESCRIPTION
The `accessTokenAndResourcePath` function does not require `fapiFinancialId`.