### PR TITLE
Use x-authorization-server-id header REFAPP-155

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ For example `/open-banking/v1.1` gives access to the 1.1 Read write Apis.
 
 #### GET Accounts for a user (Account and Transaction API)
 
-We have a hardcoded demo user `alice` with bank `abcbank` setup in [mock server](https://github.com/OpenBankingUK/reference-mock-server). To access demo accounts for this user please setup the following `ENVS` (already configured in [`.env.sample`](https://github.com/OpenBankingUK/tpp-reference-server/blob/master/.env.sample).
+We have a hardcoded demo user `alice` in [mock server](https://github.com/OpenBankingUK/reference-mock-server). To access demo accounts for this user please setup the following `ENVS` (already configured in [`.env.sample`](https://github.com/OpenBankingUK/tpp-reference-server/blob/master/.env.sample).
 
 ```sh
-curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts
+curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'x-authorization-server-id: aaaj4NmBD8lQxmLh2O' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts
 ```
 
 [Here's a sample response](https://www.openbanking.org.uk/read-write-apis/account-transaction-api/v1-1-0/#accounts-bulk-response).
@@ -147,7 +147,7 @@ curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'Accept:
 Using the same demo account as above.
 
 ```sh
-curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts/22289/product
+curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'x-authorization-server-id: aaaj4NmBD8lQxmLh2O' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts/22289/product
 ```
 
 [Here's a sample response](https://www.openbanking.org.uk/read-write-apis/account-transaction-api/v1-1-0/#product-specific-account-response).
@@ -157,7 +157,7 @@ curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'Accept:
 Using the same demo account as above.
 
 ```sh
-curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts/22289/balances
+curl -X GET -H 'Authorization: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'x-authorization-server-id: aaaj4NmBD8lQxmLh2O' -H 'Accept: application/json'  http://localhost:8003/open-banking/v1.1/accounts/22289/balances
 ```
 
 [Here's a sample response](https://www.openbanking.org.uk/read-write-apis/account-transaction-api/v1-1-0/#balances-specific-account-response).

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -62,6 +62,14 @@ const fapiFinancialIdFor = async (authServerId) => {
   throw err;
 };
 
+const requireAuthorisationServerId = async (req, res, next) => {
+  const authServerId = req.headers['x-authorization-server-id'];
+  if (!authServerId) {
+    return res.status(400).send('request missing x-authorization-server-id header');
+  }
+  return next();
+};
+
 const resourceServerHost = async (authServerId) => {
   const config = await obDirectoryConfig(authServerId);
   if (config && config.BaseApiDNSUri) {
@@ -201,4 +209,5 @@ exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;
 exports.setAuthServerConfig = setAuthServerConfig;
 exports.fapiFinancialIdFor = fapiFinancialIdFor;
+exports.requireAuthorisationServerId = requireAuthorisationServerId;
 exports.ASPSP_AUTH_SERVERS_COLLECTION = ASPSP_AUTH_SERVERS_COLLECTION;

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -3,6 +3,7 @@ const {
   authorisationEndpoint,
   issuer,
   fapiFinancialIdFor,
+  requireAuthorisationServerId,
   authorisationServersForClient,
   storeAuthorisationServers,
   tokenEndpoint,
@@ -17,6 +18,7 @@ exports.authorisationServersForClient = authorisationServersForClient;
 exports.authorisationEndpoint = authorisationEndpoint;
 exports.issuer = issuer;
 exports.fapiFinancialIdFor = fapiFinancialIdFor;
+exports.requireAuthorisationServerId = requireAuthorisationServerId;
 exports.storeAuthorisationServers = storeAuthorisationServers;
 exports.tokenEndpoint = tokenEndpoint;
 exports.resourceServerHost = resourceServerHost;

--- a/app/index.js
+++ b/app/index.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const { session } = require('./session');
 const { requireAuthorization } = require('./session');
+const { requireAuthorisationServerId } = require('./authorisation-servers');
 const { login } = require('./session');
 const { resourceRequestHandler } = require('./request-data/ob-proxy.js');
 const { OBAccountPaymentServiceProviders } = require('./ob-directory');
@@ -32,19 +33,19 @@ app.use(
   OBAccountPaymentServiceProviders,
 );
 
-app.all('/account-request-authorise-consent', requireAuthorization);
+app.all('/account-request-authorise-consent', requireAuthorization, requireAuthorisationServerId);
 app.post('/account-request-authorise-consent', accountRequestAuthoriseConsent);
 
-app.all('/payment-authorise-consent', requireAuthorization);
+app.all('/payment-authorise-consent', requireAuthorization, requireAuthorisationServerId);
 app.post('/payment-authorise-consent', paymentAuthoriseConsent);
 
-app.all('/payment-submissions', requireAuthorization);
+app.all('/payment-submissions', requireAuthorization, requireAuthorisationServerId);
 app.post('/payment-submissions', paymentSubmission);
 
 app.all('/tpp/authorized', requireAuthorization);
 app.get('/tpp/authorized', authorisationCodeGrantedHandler);
 
-app.all('/open-banking/*', requireAuthorization);
+app.all('/open-banking/*', requireAuthorization, requireAuthorisationServerId);
 app.use('/open-banking', resourceRequestHandler);
 app.use('/session/check', session.check);
 

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -10,7 +10,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const sessionId = req.headers['authorization'];
-    const { authorisationServerId } = req.body;
+    const authorisationServerId = req.headers['x-authorization-server-id'];
     const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
 
     debug(`authorisationServerId: ${authorisationServerId}`);

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -9,7 +9,7 @@ const paymentAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const sessionId = req.headers['authorization'];
-    const { authorisationServerId } = req.body;
+    const authorisationServerId = req.headers['x-authorization-server-id'];
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;
     const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);

--- a/app/setup-request/setup-request.js
+++ b/app/setup-request/setup-request.js
@@ -16,14 +16,6 @@ const resourceServerPath = async (authorisationServerId) => {
   return null;
 };
 
-const validateParameter = (authorisationServerId) => {
-  if (!authorisationServerId) {
-    const error = new Error('authorisationServerId missing from request payload');
-    error.status = 400;
-    throw error;
-  }
-};
-
 // Returns access-token when request successful
 const createAccessToken = async (authorisationServerId) => {
   const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
@@ -42,7 +34,6 @@ const createAccessToken = async (authorisationServerId) => {
 };
 
 const accessTokenAndResourcePath = async (authorisationServerId) => {
-  validateParameter(authorisationServerId);
   const accessToken = await createAccessToken(authorisationServerId);
   const resourcePath = await resourceServerPath(authorisationServerId);
   return { accessToken, resourcePath };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -143,6 +143,7 @@ describe('Proxy', () => {
   beforeEach(async () => {
     await setAuthServerConfig(authServerId, {
       obDirectoryConfig: {
+        OBOrganisationId: fapiFinancialId,
         BaseApiDNSUri: resourceApiHost,
       },
     });
@@ -165,7 +166,6 @@ describe('Proxy', () => {
           .get('/open-banking/v1.1/accounts')
           .set('Accept', 'application/json')
           .set('authorization', sessionId)
-          .set('x-fapi-financial-id', fapiFinancialId)
           .set('x-authorization-server-id', authServerId)
           .end((e, r) => {
             assert.equal(r.status, 200);
@@ -176,7 +176,7 @@ describe('Proxy', () => {
     });
   });
 
-  it('returns 500 response for missing x-fapi-financial-id', (done) => {
+  it('returns 400 response for missing x-authorization-server-id', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
       setTokenPayload(sessionId, tokenPayload).then(() => {
@@ -184,26 +184,8 @@ describe('Proxy', () => {
           .get('/open-banking/v1.1/accounts')
           .set('Accept', 'application/json')
           .set('authorization', sessionId)
-          .set('x-authorization-server-id', authServerId)
           .end((e, r) => {
-            assert.equal(r.status, 500);
-            done();
-          });
-      });
-    });
-  });
-
-  it('returns 500 response for missing x-authorization-server-id', (done) => {
-    login(app).end((err, res) => {
-      const sessionId = res.body.sid;
-      setTokenPayload(sessionId, tokenPayload).then(() => {
-        request(app)
-          .get('/open-banking/v1.1/accounts')
-          .set('Accept', 'application/json')
-          .set('authorization', sessionId)
-          .set('x-fapi-financial-id', fapiFinancialId)
-          .end((e, r) => {
-            assert.equal(r.status, 500);
+            assert.equal(r.status, 400);
             done();
           });
       });

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -66,7 +66,8 @@ const sessionId = 'testSession';
 const doPost = app => request(app)
   .post('/account-request-authorise-consent')
   .set('authorization', sessionId)
-  .send({ authorisationServerId });
+  .set('x-authorization-server-id', authorisationServerId)
+  .send();
 
 const parseState = state => JSON.parse(Buffer.from(state, 'base64').toString('utf8'));
 

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -66,7 +66,8 @@ const sessionId = 'testSession';
 const doPost = app => request(app)
   .post('/payment-authorise-consent')
   .set('authorization', sessionId)
-  .send({ authorisationServerId });
+  .set('x-authorization-server-id', authorisationServerId)
+  .send();
 
 const parseState = state => JSON.parse(Buffer.from(state, 'base64').toString('utf8'));
 

--- a/test/setup-request/setup-request.test.js
+++ b/test/setup-request/setup-request.test.js
@@ -1,19 +1,9 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const { checkErrorThrown } = require('../utils');
 const { accessTokenAndResourcePath } = require('../../app/setup-request'); // eslint-disable-line
 
 const authorisationServerId = 'testAuthorisationServerId';
-
-describe('accessTokenAndResourcePath called with blank authorisationServerId', () => {
-  it('throws error with 400 status set', async () => {
-    await checkErrorThrown(
-      async () => accessTokenAndResourcePath(null),
-      400, 'authorisationServerId missing from request payload',
-    );
-  });
-});
 
 describe('accessTokenAndResourcePath called with valid parameters', () => {
   const token = 'access-token';


### PR DESCRIPTION
- Add middleware to check `x-authorization-server-id` header.
- For consistency, always obtain authServerId from `x-authorization-server-id` header, instead of from posted JSON payload.
- Add `x-authorization-server-id` to examples in readme.

Tested locally with client e2e tests.