### PR TITLE
REFAPP-147 `updateAuthServersAndOpenIds` should load ENVs from .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,24 +343,21 @@ The server has to be configured with
 ## Configuration of ASPSP Authorisation Servers
 
 ### Adding and Updating ASPSP authorisation servers
+This is the first step - NOTHING WORKS IF THIS IS NOT SUCCESSFUL.
 
 Bootstrapping or updating the list of ASPSP authorisation servers in MongoDB is a manual task. For each authorisation server the OpenId config is also fetched and stored in the database.
 
-You have to ensure all the necessary ENVs are configured correctly and then run:
+When run locally the required ENV vars will be loaded from the `.env` file, otherwise they will be loaded from the shell.
 
 ```sh
 # Locally
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run updateAuthServersAndOpenIds
+DEBUG=debug,log npm run updateAuthServersAndOpenIds
 
 # Remotely on Heroku
 heroku run npm run updateAuthServersAndOpenIds --remote heroku
 ```
 
 Now calling the `/account-payment-service-provider-authorisation-servers` endpoint returns the correctly formatted list of ASPSP authorisation servers previously fetched from OB Directory.
-
-> __NOTE__
-
-> If you don't add client credentials you will get an EMPTY ASPSP server list.
 
 ### Listing available ASPSP authorisation servers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,6 +555,11 @@
         "isarray": "1.0.0"
       }
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "debug": "^3.1.0",
+    "dotenv": "4.0.0",
     "env-var": "3.0.2",
     "express": "^4.15.5",
     "express-http-proxy": "^1.0.7",

--- a/scripts/update-auth-server-and-open-id-configs.js
+++ b/scripts/update-auth-server-and-open-id-configs.js
@@ -1,13 +1,19 @@
 const path = require('path');
 const dotenv = require('dotenv');
+const debug = require('debug')('debug');
+const log = require('debug')('log');
 
-dotenv.load({ path: path.join(__dirname, '..', '.env') });
+const ENVS = dotenv.load({ path: path.join(__dirname, '..', '.env') });
+debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
 
 const { updateOpenIdConfigs } = require('../app/authorisation-servers');
 const { fetchOBAccountPaymentServiceProviders } = require('../app/ob-directory');
 
 const cacheLatestConfigs = async () => {
+  log('Running fetchOBAccountPaymentServiceProviders');
   await fetchOBAccountPaymentServiceProviders();
+
+  log('Running updateOpenIdConfigs');
   await updateOpenIdConfigs();
 };
 

--- a/scripts/update-auth-server-and-open-id-configs.js
+++ b/scripts/update-auth-server-and-open-id-configs.js
@@ -1,3 +1,8 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.load({ path: path.join(__dirname, '..', '.env') });
+
 const { updateOpenIdConfigs } = require('../app/authorisation-servers');
 const { fetchOBAccountPaymentServiceProviders } = require('../app/ob-directory');
 


### PR DESCRIPTION
* Started using [dotenv](https://www.npmjs.com/package/dotenv) to load ENVs from `.env` file.
* Added better debugging and logging for easier triage.
* README updates.