### PR TITLE
REFAPP-158 `listAuthServers` should load ENVs from .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,11 +361,15 @@ Now calling the `/account-payment-service-provider-authorisation-servers` endpoi
 
 ### Listing available ASPSP authorisation servers
 
-To list authorisation servers currently in the database, run:
+The commands below will list authorisation servers currently in the database.
+
+When run locally the required ENV vars will be loaded from the `.env` file, otherwise they will be loaded from the shell.
+
+Run:
 
 ```sh
 # Locally
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run listAuthServers --silent
+DEBUG=debug,log npm run listAuthServers
 
 # Remotely on Heroku
 heroku run npm run listAuthServers --remote heroku

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -1,3 +1,10 @@
+const path = require('path');
+const dotenv = require('dotenv');
+const debug = require('debug')('debug');
+
+const ENVS = dotenv.load({ path: path.join(__dirname, '..', '.env') });
+debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
+
 const { allAuthorisationServers } = require('../app/authorisation-servers');
 
 const authServerRows = async () => {


### PR DESCRIPTION
* `listAuthServers` now uses [dotenv](https://www.npmjs.com/package/dotenv).
* Updates related details in `README`.