### PR TITLE
REFAPP-159 `saveCreds` should load ENVs from .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,11 +383,13 @@ cccbN8iAsMh74sOXhk CCC Example Bank     CCC Example PLC        GB:FCA:789 cccMh7
 
 There is a script to input and store client credentials against ASPSP Auth Server configuration.
 
+When run locally the required ENV vars will be loaded from the `.env` file, otherwise they will be loaded from the shell.
+
 Example Usages
 
 ```sh
 # Locally
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
+npm run saveCreds authServerId=123 clientId=456 clientSecret=789  
 
 # Remotely on Heroku
 heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --remote heroku
@@ -398,11 +400,11 @@ heroku run npm run saveCreds authServerId=123 clientId=456 clientSecret=789 --re
 ##### Locally
 
 ```sh
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O clientId=spoofClientId clientSecret=spoofClientSecret
+DEBUG=debug,log npm run saveCreds authServerId=aaaj4NmBD8lQxmLh2O clientId=spoofClientId clientSecret=spoofClientSecret
 
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
+DEBUG=debug,log npm run saveCreds authServerId=bbbX7tUB4fPIYB0k1m clientId=spoofClientId clientSecret=spoofClientSecret
 
-MONGODB_URI='localhost:27017/sample-tpp-server' npm run saveCreds authServerId=cccbN8iAsMh74sOXhk clientId=spoofClientId clientSecret=spoofClientSecret
+DEBUG=debug,log npm run saveCreds authServerId=cccbN8iAsMh74sOXhk clientId=spoofClientId clientSecret=spoofClientSecret
 ```
 
 ##### Remotely on Heroku

--- a/scripts/add-client-credentials.js
+++ b/scripts/add-client-credentials.js
@@ -1,5 +1,12 @@
-const { updateClientCredentials } = require('../app/authorisation-servers');
+const path = require('path');
+const dotenv = require('dotenv');
+const debug = require('debug')('debug');
 const error = require('debug')('error');
+
+const ENVS = dotenv.load({ path: path.join(__dirname, '..', '.env') });
+debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
+
+const { updateClientCredentials } = require('../app/authorisation-servers');
 
 const args = process.argv.slice(2).reduce((acc, arg) => {
   const [k, v = true] = arg.split('=');


### PR DESCRIPTION
* `saveCreds` now uses [dotenv](https://www.npmjs.com/package/dotenv).
* Updates related details in `README`.