### PR TITLE
Make x-jws-signature header optional

### DIFF
--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -40,7 +40,6 @@ const postAccountRequests = async (resourceServerPath, accessToken,
       .set('content-type', 'application/json; charset=utf-8')
       .set('accept', 'application/json; charset=utf-8')
       .set('x-fapi-financial-id', fapiFinancialId)
-      .set('x-jws-signature', 'not-required-swagger-to-be-changed')
       .send(body);
     debug(`${response.status} response for ${accountRequestsUri}`);
     return response.body;

--- a/app/setup-payment/payments.js
+++ b/app/setup-payment/payments.js
@@ -24,7 +24,6 @@ const postPayments = async (resourceServerPath, paymentPathEndpoint, headers, pa
     log(`POST to ${paymentsUri}`);
     const payment = setupMutualTLS(request.post(paymentsUri))
       .set('authorization', `Bearer ${headers.accessToken}`)
-      .set('x-jws-signature', 'not-required-swagger-to-be-changed')
       .set('x-fapi-financial-id', headers.fapiFinancialId)
       .set('x-fapi-interaction-id', headers.interactionId)
       .set('x-idempotency-key', headers.idempotencyKey)
@@ -32,6 +31,7 @@ const postPayments = async (resourceServerPath, paymentPathEndpoint, headers, pa
       .set('accept', 'application/json; charset=utf-8');
     if (headers.customerLastLogged) payment.set('x-fapi-customer-last-logged-time', headers.customerLastLogged);
     if (headers.customerIp) payment.set('x-fapi-customer-ip-address', headers.customerIp);
+    if (headers.jwsSignature) payment.set('x-jws-signature', headers.jwsSignature);
 
     payment.send(paymentData);
     const response = await payment;

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -24,13 +24,12 @@ describe('postAccountRequests', () => {
 
   const accessToken = '2YotnFZFEjr1zCsicMWpAA';
   const fapiFinancialId = 'abc';
-  const jwsSignature = 'not-required-swagger-to-be-changed';
 
   nock(/example\.com/)
     .post('/open-banking/v1.1/account-requests')
     .matchHeader('authorization', `Bearer ${accessToken}`) // required
     .matchHeader('x-fapi-financial-id', fapiFinancialId) // required
-    .matchHeader('x-jws-signature', jwsSignature) // required
+    // optional x-jws-signature
     // optional x-fapi-customer-last-logged-time
     // optional x-fapi-customer-ip-address
     // optional x-fapi-interaction-id

--- a/test/setup-payment/payments.test.js
+++ b/test/setup-payment/payments.test.js
@@ -39,7 +39,7 @@ describe('postPayments request to remote payment endpoints', () => {
   const interactionId = 'xyz';
   const customerIp = '10.10.0.1';
   const customerLastLogged = 'Sun, 10 Sep 2017 19:43:31 UTC';
-  const jwsSignature = 'not-required-swagger-to-be-changed';
+  const jwsSignature = 'testJwsSignature';
 
   const headers = {
     interactionId,
@@ -48,6 +48,7 @@ describe('postPayments request to remote payment endpoints', () => {
     accessToken,
     fapiFinancialId,
     idempotencyKey,
+    jwsSignature,
   };
 
   const paymentData = {


### PR DESCRIPTION
As this header is optional in v1.1.1 of specs.

Tested successfully against reference bank.