### PR TITLE
Ref #REFAPP-112 Allow Multiple Sessions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,3 @@
-AUTHORIZATION=alice
 CLIENT_SCOPES='ASPSPReadAccess TPPReadAccess AuthoritiesReadAccess'
 DEBUG=error,log,debug
 MONGODB_URI=mongodb://localhost:27017/sample-tpp-server

--- a/README.md
+++ b/README.md
@@ -475,7 +475,6 @@ DEBUG=error,log \
   SIGNING_KEY='' \
   TRANSPORT_CERT='' \
   TRANSPORT_KEY='' \
-  AUTHORIZATION=alice \
   MONGODB_URI=mongodb://localhost:27017/sample-tpp-server \
   PORT=8003 \
   npm start
@@ -483,7 +482,6 @@ DEBUG=error,log \
 ```
 
 * Set debug log levels using `DEBUG` env var.
-* Set hardcoded auth token using `AUTHORIZATION` env var.
 * Set OB Provisioned status using `OB_PROVISIONED` env var.
 * Set OB Directory host using `OB_DIRECTORY_HOST` env var.
 * Set OB Directory access_token using `OB_DIRECTORY_ACCESS_TOKEN` env var.
@@ -518,7 +516,6 @@ heroku create --region eu <newname>
 heroku addons:create redistogo # or any other redis add-on
 heroku addons:create mongolab:sandbox
 
-heroku config:set AUTHORIZATION=<mock-token>
 heroku config:set DEBUG=error,log
 heroku config:set OB_PROVISIONED=false
 heroku config:set OB_DIRECTORY_HOST=http://ob-directory.example.com

--- a/app/index.js
+++ b/app/index.js
@@ -4,7 +4,6 @@ const express = require('express');
 const morgan = require('morgan');
 const cors = require('cors');
 const bodyParser = require('body-parser');
-const { session } = require('./session');
 const { requireAuthorization } = require('./session');
 const { requireAuthorisationServerId } = require('./authorisation-servers');
 const { login } = require('./session');
@@ -48,6 +47,5 @@ app.get('/tpp/authorized', authorisationCodeGrantedHandler);
 
 app.all('/open-banking/*', requireAuthorization, requireAuthorisationServerId);
 app.use('/open-banking', resourceRequestHandler);
-app.use('/session/check', session.check);
 
 exports.app = app;

--- a/app/session/authorization.js
+++ b/app/session/authorization.js
@@ -1,26 +1,19 @@
 const { session } = require('./session');
 
-const authorization = process.env.AUTHORIZATION;
-
-/**
- * @description Only return the authorization if there is a valid session
- * @param sid
- * @returns {*}
- */
-const getAuthFromSession = (candidate, callback) => {
+const validSession = (candidate, callback) => {
   session.getId(candidate, (err, sid) => {
     if (sid === candidate) {
-      return callback(authorization);
+      return callback(true);
     }
-    return callback('');
+    return callback(false);
   });
 };
 
 const requireAuthorization = (req, res, next) => {
   const sid = req.headers.authorization;
   if (sid) {
-    getAuthFromSession(sid, (token) => {
-      if (token.length === 0) {
+    validSession(sid, (valid) => {
+      if (!valid) {
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.status(401).send();
       } else {
@@ -34,4 +27,3 @@ const requireAuthorization = (req, res, next) => {
 };
 
 exports.requireAuthorization = requireAuthorization;
-exports.getAuthFromSession = getAuthFromSession;

--- a/app/session/authorization.js
+++ b/app/session/authorization.js
@@ -8,7 +8,7 @@ const authorization = process.env.AUTHORIZATION;
  * @returns {*}
  */
 const getAuthFromSession = (candidate, callback) => {
-  session.getId((err, sid) => {
+  session.getId(candidate, (err, sid) => {
     if (sid === candidate) {
       return callback(authorization);
     }

--- a/app/session/session.js
+++ b/app/session/session.js
@@ -3,8 +3,8 @@ const { store } = require('./persistence.js');
 const log = require('debug')('log');
 
 const session = (() => {
-  const setId = sid => store.set('session_id', sid);
-  const getId = cb => store.get('session_id', cb);
+  const setId = sid => store.set(sid, sid);
+  const getId = (sid, cb) => store.get(sid, cb);
   const setAccessToken = accessToken => store.set('ob_directory_access_token', JSON.stringify(accessToken));
   const getAccessToken = cb => store.get('ob_directory_access_token', cb);
 
@@ -14,10 +14,10 @@ const session = (() => {
       if (sid !== candidate) {
         return cb(null);
       }
-      store.remove('session_id'); // Async but we kinda don't care :-/
+      store.remove(candidate); // Async but we kinda don't care :-/
       return cb(sid);
     };
-    store.get('session_id', sessHandler);
+    store.get(candidate, sessHandler);
   };
 
   const newId = () => {
@@ -27,7 +27,8 @@ const session = (() => {
   };
 
   const check = (req, res) => {
-    getId((err, sid) => {
+    const candidate = req.headers.authorization;
+    getId(candidate, (err, sid) => {
       if (err) {
         res.sendStatus(500);
       } else {

--- a/app/session/session.js
+++ b/app/session/session.js
@@ -26,18 +26,6 @@ const session = (() => {
     return mySid;
   };
 
-  const check = (req, res) => {
-    const candidate = req.headers.authorization;
-    getId(candidate, (err, sid) => {
-      if (err) {
-        res.sendStatus(500);
-      } else {
-        res.setHeader('Content-Type', 'application/json');
-        res.send(JSON.stringify(sid));
-      }
-    });
-  };
-
   const deleteAll = async () => {
     await store.deleteAll();
   };
@@ -49,7 +37,6 @@ const session = (() => {
     getAccessToken,
     destroy,
     newId,
-    check,
     deleteAll,
   };
 })();


### PR DESCRIPTION
Also
- Remove unused `session/check` route, and remove `session.check` function.
- Remove unneeded `AUTHORIZATION` env var.
- Rename `getAuthFromSession` function to `validSession`, returns `true` when session exists, otherwise `false`.
- Use `validSession` to check authorization header represents valid session id.