### PR TITLE
REFAPP-189 Part 2, Track active consent ttl in /tpp/authorized redirection 

### DIFF
--- a/app/authorise/access-tokens.js
+++ b/app/authorise/access-tokens.js
@@ -3,19 +3,19 @@ const debug = require('debug')('debug');
 
 const ACCESS_TOKENS_COLLECTION = 'accessTokens';
 
-const tokenPayload = async sessionId => get(ACCESS_TOKENS_COLLECTION, sessionId);
+const tokenPayload = async username => get(ACCESS_TOKENS_COLLECTION, username);
 
-const setTokenPayload = async (sessionId, payload) =>
-  set(ACCESS_TOKENS_COLLECTION, payload, sessionId);
+const setTokenPayload = async (username, payload) =>
+  set(ACCESS_TOKENS_COLLECTION, payload, username);
 
-const accessToken = async (sessionId) => {
-  const payload = await tokenPayload(sessionId);
-  debug(`accessToken#sessionId: ${sessionId}`);
+const accessToken = async (username) => {
+  const payload = await tokenPayload(username);
+  debug(`accessToken#username: ${username}`);
   debug(`accessToken#payload: ${JSON.stringify(payload)}`);
   if (payload && payload.access_token) {
     return payload.access_token;
   }
-  const err = new Error(`access token for session ${sessionId} not found`);
+  const err = new Error(`access token for username ${username} not found`);
   err.status = 500;
   throw err;
 };

--- a/app/authorise/authorisation-code-granted.js
+++ b/app/authorise/authorisation-code-granted.js
@@ -3,7 +3,6 @@ const { setTokenPayload } = require('./access-tokens');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('../authorisation-servers');
 const { session } = require('../session');
-const util = require('util');
 const debug = require('debug')('debug');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();

--- a/app/authorise/authorisation-code-granted.js
+++ b/app/authorise/authorisation-code-granted.js
@@ -2,6 +2,8 @@ const env = require('env-var');
 const { setTokenPayload } = require('./access-tokens');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('../authorisation-servers');
+const { session } = require('../session');
+const util = require('util');
 const debug = require('debug')('debug');
 
 const redirectionUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
@@ -24,7 +26,10 @@ const handler = async (req, res) => {
     const sessionId = req.headers.authorization;
     debug(`sessionId: ${sessionId}`);
     debug(`tokenPayload: ${JSON.stringify(tokenPayload)}`);
-    await setTokenPayload(sessionId, tokenPayload);
+
+    const sessionData = JSON.parse(await session.getDataAsync(sessionId));
+    debug(`sessionData.username: ${sessionData.username}`);
+    await setTokenPayload(sessionData.username, tokenPayload);
     return res.status(204).send();
   } catch (err) {
     const status = err.status ? err.status : 500;

--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -3,6 +3,7 @@ const { setupMutualTLS } = require('../certs-util');
 const { resourceServerPath } = require('../authorisation-servers');
 const { accessToken } = require('../authorise');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
+const { session } = require('../session');
 const debug = require('debug')('debug');
 const error = require('debug')('error');
 
@@ -21,10 +22,12 @@ const resourceRequestHandler = async (req, res) => {
   }
   const path = `/open-banking${req.path}`;
   const proxiedUrl = `${host}${path}`;
-  const token = await accessToken(sessionId);
+  const sessionData = JSON.parse(await session.getDataAsync(sessionId));
+  const token = await accessToken(sessionData.username);
   const bearerToken = `Bearer ${token}`;
 
   debug(`proxiedUrl ${proxiedUrl}`);
+  debug(`sessionData.username: ${sessionData.username}`);
   debug(`bearerToken ${bearerToken}`);
   debug(`xFapiFinancialId ${xFapiFinancialId}`);
 

--- a/app/session/authorization.js
+++ b/app/session/authorization.js
@@ -1,7 +1,7 @@
 const { session } = require('./session');
 
 const validSession = (candidate, callback) => {
-  session.getData(candidate, (err, data) => callback(data));
+  session.getData(candidate, (err, data) => callback(!!data));
 };
 
 const requireAuthorization = (req, res, next) => {

--- a/app/session/authorization.js
+++ b/app/session/authorization.js
@@ -1,7 +1,7 @@
 const { session } = require('./session');
 
 const validSession = (candidate, callback) => {
-  session.getData(candidate, (err, data) => callback(data && JSON.parse(data).sid === candidate));
+  session.getData(candidate, (err, data) => callback(data));
 };
 
 const requireAuthorization = (req, res, next) => {

--- a/app/session/session.js
+++ b/app/session/session.js
@@ -1,10 +1,12 @@
 const uuidv1 = require('uuid/v1'); // Timestamp based UUID
 const { store } = require('./persistence.js');
+const util = require('util');
 const log = require('debug')('log');
 
 const session = (() => {
   const setData = (sid, username) => store.set(sid, JSON.stringify({ sid, username }));
   const getData = (sid, cb) => store.get(sid, cb);
+  const getDataAsync = util.promisify(getData);
   const setAccessToken = accessToken => store.set('ob_directory_access_token', JSON.stringify(accessToken));
   const getAccessToken = cb => store.get('ob_directory_access_token', cb);
 
@@ -34,6 +36,7 @@ const session = (() => {
   return {
     setData,
     getData,
+    getDataAsync,
     setAccessToken,
     getAccessToken,
     destroy,

--- a/test/authorise/access-tokens.test.js
+++ b/test/authorise/access-tokens.test.js
@@ -5,7 +5,7 @@ const { ACCESS_TOKENS_COLLECTION } = require('../../app/authorise/access-tokens'
 
 const { drop } = require('../../app/storage.js');
 
-const sessionId = 'testSession';
+const username = 'testUsername';
 const token = 'testAccessToken';
 const tokenPayload = {
   access_token: token,
@@ -22,7 +22,7 @@ describe('setTokenPayload', () => {
   });
 
   it('stores payload and allows accessToken to be retrieved', async () => {
-    await setTokenPayload(sessionId, tokenPayload);
-    assert.equal(await accessToken(sessionId), token);
+    await setTokenPayload(username, tokenPayload);
+    assert.equal(await accessToken(username), token);
   });
 });

--- a/test/authorise/authorisation-code-granted.test.js
+++ b/test/authorise/authorisation-code-granted.test.js
@@ -3,7 +3,6 @@ const proxyquire = require('proxyquire');
 const env = require('env-var');
 const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
-const util = require('util');
 
 const redirectionUrl = 'http://localhost:9999/tpp/authorized';
 const clientId = 'id';
@@ -30,6 +29,7 @@ describe('Authorized Code Granted', () => {
   let postTokenStub;
   let setTokenPayloadStub;
   let getClientCredentialsStub;
+  let sessionGetDataStub;
   let request;
   let response;
 
@@ -37,7 +37,10 @@ describe('Authorized Code Granted', () => {
     setTokenPayloadStub = sinon.stub();
     postTokenStub = sinon.stub().returns(tokenResponsePayload);
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
-    sessionGetDataStub = sinon.stub().returns(JSON.stringify({ sid: sessionId, username: username }));
+    sessionGetDataStub = sinon.stub().returns(JSON.stringify({
+      sid: sessionId,
+      username,
+    }));
     redirection = proxyquire('../../app/authorise/authorisation-code-granted.js', {
       'env-var': env.mock({
         SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
@@ -49,8 +52,8 @@ describe('Authorized Code Granted', () => {
       './access-tokens': { setTokenPayload: setTokenPayloadStub },
       '../session': {
         session: {
-          getDataAsync: sessionGetDataStub
-        }
+          getDataAsync: sessionGetDataStub,
+        },
       },
     });
 

--- a/test/authorise/authorisation-code-granted.test.js
+++ b/test/authorise/authorisation-code-granted.test.js
@@ -3,6 +3,7 @@ const proxyquire = require('proxyquire');
 const env = require('env-var');
 const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
+const util = require('util');
 
 const redirectionUrl = 'http://localhost:9999/tpp/authorized';
 const clientId = 'id';
@@ -11,6 +12,7 @@ const authorisationServerId = '123';
 const accessToken = 'access-token';
 const authorisationCode = '12345_67xxx';
 const sessionId = 'testSession';
+const username = 'testUser';
 
 const tokenRequestPayload = {
   grant_type: 'authorization_code', // eslint-disable-line quote-props
@@ -35,6 +37,7 @@ describe('Authorized Code Granted', () => {
     setTokenPayloadStub = sinon.stub();
     postTokenStub = sinon.stub().returns(tokenResponsePayload);
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
+    sessionGetDataStub = sinon.stub().returns(JSON.stringify({ sid: sessionId, username: username }));
     redirection = proxyquire('../../app/authorise/authorisation-code-granted.js', {
       'env-var': env.mock({
         SOFTWARE_STATEMENT_REDIRECT_URL: redirectionUrl,
@@ -44,6 +47,11 @@ describe('Authorized Code Granted', () => {
         getClientCredentials: getClientCredentialsStub,
       },
       './access-tokens': { setTokenPayload: setTokenPayloadStub },
+      '../session': {
+        session: {
+          getDataAsync: sessionGetDataStub
+        }
+      },
     });
 
     request = httpMocks.createRequest({
@@ -76,7 +84,7 @@ describe('Authorized Code Granted', () => {
         authorisationServerId,
         clientId, clientSecret, tokenRequestPayload,
       ));
-      assert(setTokenPayloadStub.calledWithExactly(sessionId, tokenResponsePayload));
+      assert(setTokenPayloadStub.calledWithExactly(username, tokenResponsePayload));
     });
 
     describe('error handling', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,9 @@ const assert = require('assert');
 
 const nock = require('nock');
 
+const username = 'alice';
+const password = 'wonderland';
+
 const requestHeaders = {
   reqheaders: {
     'authorization': authorization,
@@ -33,7 +36,7 @@ nock(/example\.com/)
 const login = application => request(application)
   .post('/login')
   .set('Accept', 'x-www-form-urlencoded')
-  .send({ u: 'alice', p: 'wonderland' });
+  .send({ u: username, p: password });
 
 describe('Session Creation (Login)', () => {
   it('returns "Access-Control-Allow-Origin: *" header', (done) => {
@@ -161,7 +164,8 @@ describe('Proxy', () => {
   it('returns proxy 200 response for /open-banking/v1.1/accounts with valid session', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      setTokenPayload(sessionId, tokenPayload).then(() => {
+      setTokenPayload(username, tokenPayload)
+      .then(() => {
         request(app)
           .get('/open-banking/v1.1/accounts')
           .set('Accept', 'application/json')
@@ -172,14 +176,15 @@ describe('Proxy', () => {
             assert.equal(r.body.hi, 'ya');
             done();
           });
-      });
+      })
+      .catch((err) => console.log('ERRRRRR', err));
     });
   });
 
   it('returns 400 response for missing x-authorization-server-id', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      setTokenPayload(sessionId, tokenPayload).then(() => {
+      setTokenPayload(username, tokenPayload).then(() => {
         request(app)
           .get('/open-banking/v1.1/accounts')
           .set('Accept', 'application/json')
@@ -195,7 +200,7 @@ describe('Proxy', () => {
   it('returns proxy 404 reponse for /open-banking/non-existing', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      setTokenPayload(sessionId, tokenPayload).then(() => {
+      setTokenPayload(username, tokenPayload).then(() => {
         request(app)
           .get('/open-banking/non-existing')
           .set('Accept', 'application/json')
@@ -213,7 +218,7 @@ describe('Proxy', () => {
   it('should return 404 for path != /open-banking', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      setTokenPayload(sessionId, tokenPayload).then(() => {
+      setTokenPayload(username, tokenPayload).then(() => {
         request(app)
           .get('/open-banking-invalid')
           .set('Accept', 'application/json')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -164,8 +164,7 @@ describe('Proxy', () => {
   it('returns proxy 200 response for /open-banking/v1.1/accounts with valid session', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      setTokenPayload(username, tokenPayload)
-      .then(() => {
+      setTokenPayload(username, tokenPayload).then(() => {
         request(app)
           .get('/open-banking/v1.1/accounts')
           .set('Accept', 'application/json')
@@ -176,8 +175,7 @@ describe('Proxy', () => {
             assert.equal(r.body.hi, 'ya');
             done();
           });
-      })
-      .catch((err) => console.log('ERRRRRR', err));
+      });
     });
   });
 


### PR DESCRIPTION
This PR completes https://openbanking.atlassian.net/browse/REFAPP-189.

* Ensures all calls to `setTokenPayload` use the username from the current session.
* Ensures all calls to `accessToken` use the username from the current session.

We can now track the consent token. Sample data from MongoDB.

```
> db.accessTokens.find().pretty()
{
    "_id" : ObjectId("5a6616f1464ce958915b6c48"),
    "id" : "alice",
    "access_token" : "2YotnFZFEjr1zCsicMWpAA",
    "expires_in" : 3600,
    "token_type" : "bearer"
}
```