### PR TITLE
REFAPP-191 Part 1 - Add AccountRequestId to state payload

### DIFF
--- a/app/authorise/authorise-uri.js
+++ b/app/authorise/authorise-uri.js
@@ -8,12 +8,13 @@ const qs = require('qs');
 
 const registeredRedirectUrl = env.get('SOFTWARE_STATEMENT_REDIRECT_URL').asString();
 
-const statePayload = (authorisationServerId, sessionId, scope, interactionId) => {
+const statePayload = (authorisationServerId, sessionId, scope, interactionId, accountRequestId) => {
   const state = {
     authorisationServerId,
     interactionId,
     sessionId,
     scope,
+    accountRequestId,
   };
   return Buffer.from(JSON.stringify(state)).toString('base64');
 };
@@ -21,7 +22,7 @@ const statePayload = (authorisationServerId, sessionId, scope, interactionId) =>
 const generateRedirectUri = async (authorisationServerId, requestId, scope,
   sessionId, interactionId) => {
   const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
-  const state = statePayload(authorisationServerId, sessionId, scope, interactionId);
+  const state = statePayload(authorisationServerId, sessionId, scope, interactionId, requestId);
   const authEndpoint = await authorisationEndpoint(authorisationServerId);
   const authServerIssuer = await issuer(authorisationServerId);
   const signingAlgs = await requestObjectSigningAlgs(authorisationServerId);

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -10,6 +10,7 @@ const qs = require('qs');
 const { statePayload } = require('../../app/authorise/authorise-uri.js');
 
 const authorisationServerId = '123';
+const accountRequestId = 'account-request-id';
 const clientId = 'testClientId';
 const clientSecret = 'testClientSecret';
 const redirectUrl = 'http://example.com/redirect';
@@ -74,12 +75,18 @@ const doPost = app => request(app)
 const parseState = state => JSON.parse(Buffer.from(state, 'base64').toString('utf8'));
 
 describe('/account-request-authorise-consent with successful setupAccountRequest', () => {
-  const setupAccountRequestStub = sinon.stub();
+  const setupAccountRequestStub = sinon.stub().returns(accountRequestId);
   const authorisationEndpointStub = sinon.stub().returns('http://example.com/authorize');
   const app = setupApp(setupAccountRequestStub, authorisationEndpointStub);
 
   const scope = 'openid accounts';
-  const expectedStateBase64 = statePayload(authorisationServerId, sessionId, scope, interactionId);
+  const expectedStateBase64 = statePayload(
+    authorisationServerId,
+    sessionId,
+    scope,
+    interactionId,
+    accountRequestId,
+  );
   const expectedRedirectHost = 'http://example.com/authorize';
   const expectedParams = {
     client_id: clientId,
@@ -94,6 +101,7 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
     interactionId,
     scope,
     sessionId,
+    accountRequestId,
   };
 
   it('creates a redirect URI with a 200 code via the to /authorize endpoint', (done) => {


### PR DESCRIPTION
This (tiny) PR simplifies storing the `AccountRequestId` as part of the consent details.

As part of the state payload,
* The `AccountRequestId` will be passed back to the server from the client.
* The `AccountRequestId`will accompany other required consent details in same request.
* This allows us to persist all consent details in one transaction.
* And, ensures that we only track data after a successful consent attempt.