### PR TITLE
REFAPP-192 Part 2, track user consent 

### DIFF
--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -28,7 +28,7 @@ const transformServerData = (data) => {
   };
 };
 
-const getAuthServerConfig = async id => get(ASPSP_AUTH_SERVERS_COLLECTION, id);
+const getAuthServerConfig = async id => get(ASPSP_AUTH_SERVERS_COLLECTION, { id });
 
 const setAuthServerConfig = async (id, authServer) =>
   set(ASPSP_AUTH_SERVERS_COLLECTION, authServer, id);

--- a/app/authorise/access-tokens.js
+++ b/app/authorise/access-tokens.js
@@ -3,7 +3,7 @@ const debug = require('debug')('debug');
 
 const ACCESS_TOKENS_COLLECTION = 'accessTokens';
 
-const tokenPayload = async username => get(ACCESS_TOKENS_COLLECTION, username);
+const tokenPayload = async username => get(ACCESS_TOKENS_COLLECTION, { id: username });
 
 const setTokenPayload = async (username, payload) =>
   set(ACCESS_TOKENS_COLLECTION, payload, username);

--- a/app/storage.js
+++ b/app/storage.js
@@ -1,6 +1,7 @@
 const monk = require('monk');
 const error = require('debug')('error');
 const log = require('debug')('log');
+const debug = require('debug')('debug');
 
 let mongodbUri = 'localhost:27017/sample-tpp-server';
 if (process.env.MONGODB_URI) {
@@ -15,10 +16,10 @@ const db = monk(mongodbUri);
  * @param {string} id - `id` field to query.
  * @return {object} document with given `id` field, or null if none found.
  */
-const get = async (collection, id, fields = []) => {
+const get = async (collection, query = { id: null }, fields = []) => {
   try {
     const store = await db.get(collection);
-    return await store.findOne({ id }, ['-_id'].concat(fields));
+    return await store.findOne(query, ['-_id'].concat(fields));
   } catch (e) {
     error(`error in storage get: ${e.stack}`);
     throw e;
@@ -51,7 +52,7 @@ const set = async (collection, object, id) => {
     const item = Object.assign({ id }, object);
     const store = await db.get(collection);
     await store.createIndex('id'); // ensure id index exists
-    if (await get(collection, id)) {
+    if (await get(collection, { id })) {
       return await store.findOneAndUpdate({ id }, item);
     }
     return await store.insert(item);

--- a/app/storage.js
+++ b/app/storage.js
@@ -16,10 +16,12 @@ const db = monk(mongodbUri);
  * @param {string} id - `id` field to query.
  * @return {object} document with given `id` field, or null if none found.
  */
-const get = async (collection, query = { id: null }, fields = []) => {
+const get = async (collection, query = {}, fields = []) => {
   try {
     const store = await db.get(collection);
-    return await store.findOne(query, ['-_id'].concat(fields));
+    const sanitizedQuery = Object.entries(query).length === 0 ? { id: null } : query;
+    debug(`sanitizedQuery: ${JSON.stringify(sanitizedQuery)}`);
+    return await store.findOne(sanitizedQuery, ['-_id'].concat(fields));
   } catch (e) {
     error(`error in storage get: ${e.stack}`);
     throw e;

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -15,14 +15,16 @@ describe('storage set data with id', () => {
 
   it('then get with invalid id returns null', async () => {
     await set(collection, data, id);
-    const result = await get(collection, 'bad-id');
+    const query = { id: 'bad-id' };
+    const result = await get(collection, query);
     return assert.equal(null, result);
   });
 
   it('then get with id returns same data', async () => {
     await set(collection, data, id);
     const expected = Object.assign({ id }, data);
-    const result = await get(collection, id);
+    const query = { id };
+    const result = await get(collection, { id });
     return assert.deepEqual(expected, result);
   });
 
@@ -40,7 +42,8 @@ describe('storage set data with id', () => {
     await set(collection, newData, id);
 
     const expected = Object.assign({ id }, newData);
-    const result = await get(collection, id);
+    const query = { id };
+    const result = await get(collection, query);
     return assert.deepEqual(expected, result);
   });
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -13,18 +13,24 @@ describe('storage set data with id', () => {
   };
   const id = 'testId';
 
-  it('then get with invalid id returns null', async () => {
+  it('then get with invalid query returns null', async () => {
     await set(collection, data, id);
     const query = { id: 'bad-id' };
     const result = await get(collection, query);
     return assert.equal(null, result);
   });
 
-  it('then get with id returns same data', async () => {
+  it('then get with empty query returns null', async () => {
+    await set(collection, data, id);
+    const result = await get(collection, {});
+    return assert.equal(null, result);
+  });
+
+  it('then get with valid query returns same data', async () => {
     await set(collection, data, id);
     const expected = Object.assign({ id }, data);
     const query = { id };
-    const result = await get(collection, { id });
+    const result = await get(collection, query);
     return assert.deepEqual(expected, result);
   });
 


### PR DESCRIPTION
This PR extends the storage `get` method to findOne based on a query.

This allows for composite key queries which are required for the new consents collection.