### PR TITLE
REFAPP-192 track user consent

### DIFF
--- a/app/authorise/authorisation-code-granted.js
+++ b/app/authorise/authorisation-code-granted.js
@@ -34,8 +34,8 @@ const handler = async (req, res) => {
     debug(`tokenPayload: ${JSON.stringify(tokenPayload)}`);
 
     const sessionData = JSON.parse(await session.getDataAsync(sessionId));
-    const username = sessionData.username;
-    debug(`sessionData.username: ${sessionData.username}`);
+    const { username } = sessionData;
+    debug(`username: ${username}`);
     await setTokenPayload(sessionData.username, tokenPayload);
     const consentPayload = {
       username,
@@ -46,8 +46,7 @@ const handler = async (req, res) => {
       authorisationCode,
       token: tokenPayload,
     };
-    debug(`consent keys: [${ JSON.stringify({ username, authorisationServerId, scope }) }]`)
-    debug(`consentPayload: [${ JSON.stringify(consentPayload) }]`)
+
     await setConsent({ username, authorisationServerId, scope }, consentPayload);
     return res.status(204).send();
   } catch (err) {

--- a/app/authorise/authorisation-code-granted.js
+++ b/app/authorise/authorisation-code-granted.js
@@ -1,5 +1,6 @@
 const env = require('env-var');
 const { setTokenPayload } = require('./access-tokens');
+const { setConsent } = require('./consents');
 const { postToken } = require('./obtain-access-token');
 const { getClientCredentials } = require('../authorisation-servers');
 const { session } = require('../session');
@@ -11,7 +12,12 @@ const handler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     debug(`#authorisationCodeGrantedHandler request payload: ${JSON.stringify(req.body)}`);
-    const { authorisationServerId, authorisationCode } = req.body;
+    const {
+      authorisationServerId,
+      authorisationCode,
+      scope,
+      accountRequestId,
+    } = req.body;
     const { clientId, clientSecret } = await getClientCredentials(authorisationServerId);
     const accessTokenRequest = {
       grant_type: 'authorization_code',
@@ -28,10 +34,22 @@ const handler = async (req, res) => {
     debug(`tokenPayload: ${JSON.stringify(tokenPayload)}`);
 
     const sessionData = JSON.parse(await session.getDataAsync(sessionId));
+    const username = sessionData.username;
     debug(`sessionData.username: ${sessionData.username}`);
     await setTokenPayload(sessionData.username, tokenPayload);
+    const consentPayload = {
+      username,
+      authorisationServerId,
+      scope,
+      accountRequestId,
+      expirationDateTime: null,
+      authorisationCode,
+      accessToken: tokenPayload,
+    };
+    await setConsent({ username, authorisationServerId, scope }, consentPayload);
     return res.status(204).send();
   } catch (err) {
+    debug(`err: [${JSON.stringify(err)}]`);
     const status = err.status ? err.status : 500;
     return res.status(status).send({ message: err.message });
   }

--- a/app/authorise/authorisation-code-granted.js
+++ b/app/authorise/authorisation-code-granted.js
@@ -44,8 +44,10 @@ const handler = async (req, res) => {
       accountRequestId,
       expirationDateTime: null,
       authorisationCode,
-      accessToken: tokenPayload,
+      token: tokenPayload,
     };
+    debug(`consent keys: [${ JSON.stringify({ username, authorisationServerId, scope }) }]`)
+    debug(`consentPayload: [${ JSON.stringify(consentPayload) }]`)
     await setConsent({ username, authorisationServerId, scope }, consentPayload);
     return res.status(204).send();
   } catch (err) {

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -3,15 +3,15 @@ const debug = require('debug')('debug');
 
 const AUTH_SERVER_USER_CONSENTS_COLLECTION = 'authorisationServerUserConsents';
 
-const validateCompositeKey = obj => {
-  if (!Object.keys(obj).includes('username', 'authorisationServerId', 'scope')){
-    const err = new Error(`Incorrect conset compositeKey [${keys}]`);
+const validateCompositeKey = (obj) => {
+  if (!Object.keys(obj).includes('username', 'authorisationServerId', 'scope')) {
+    const err = new Error(`Incorrect conset compositeKey [${obj}]`);
     err.status = 500;
     throw err;
   }
 };
 
-const generateCompositeKey = obj => {
+const generateCompositeKey = (obj) => {
   validateCompositeKey(obj);
   return `${obj.username}:::${obj.authorisationServerId}:::${obj.scope}`;
 };
@@ -24,7 +24,8 @@ const setConsent = async (keys, payload) => {
   await set(AUTH_SERVER_USER_CONSENTS_COLLECTION, payload, compositeKey);
 };
 
-const consentPayload = async (compositeKey) => get(AUTH_SERVER_USER_CONSENTS_COLLECTION, compositeKey);
+const consentPayload = async compositeKey =>
+  get(AUTH_SERVER_USER_CONSENTS_COLLECTION, compositeKey);
 
 const consent = async (keys) => {
   const compositeKey = generateCompositeKey(keys);

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -5,7 +5,7 @@ const AUTH_SERVER_USER_CONSENTS_COLLECTION = 'authorisationServerUserConsents';
 
 const validateCompositeKey = (obj) => {
   if (!Object.keys(obj).includes('username', 'authorisationServerId', 'scope')) {
-    const err = new Error(`Incorrect conset compositeKey [${obj}]`);
+    const err = new Error(`Incorrect consent compositeKey [${obj}]`);
     err.status = 500;
     throw err;
   }
@@ -33,15 +33,20 @@ const consent = async (keys) => {
   debug(`consent#id (compositeKey): ${compositeKey}`);
   debug(`consent#payload: ${JSON.stringify(payload)}`);
   if (!payload) {
-    const err = new Error(`consent for id ${JSON.stringify(keys)} not found`);
+    const err = new Error(`User [${keys.username}] has not yet given consent to access their ${keys.scope}`);
     err.status = 500;
     throw err;
   }
   return payload;
 };
 
+const consentAccessToken = async (keys) => {
+  const existing = await consent(keys);
+  return existing.token.access_token;
+};
 
 exports.generateCompositeKey = generateCompositeKey;
 exports.setConsent = setConsent;
 exports.consent = consent;
+exports.consentAccessToken = consentAccessToken;
 exports.AUTH_SERVER_USER_CONSENTS_COLLECTION = AUTH_SERVER_USER_CONSENTS_COLLECTION;

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -1,0 +1,46 @@
+const { get, set } = require('../storage');
+const debug = require('debug')('debug');
+
+const AUTH_SERVER_USER_CONSENTS_COLLECTION = 'authorisationServerUserConsents';
+
+const validateCompositeKey = obj => {
+  if (!Object.keys(obj).includes('username', 'authorisationServerId', 'scope')){
+    const err = new Error(`Incorrect conset compositeKey [${keys}]`);
+    err.status = 500;
+    throw err;
+  }
+};
+
+const generateCompositeKey = obj => {
+  validateCompositeKey(obj);
+  return `${obj.username}:::${obj.authorisationServerId}:::${obj.scope}`;
+};
+
+const setConsent = async (keys, payload) => {
+  debug(`#setConsent keys: [${JSON.stringify(keys)}]`);
+  debug(`#setConsent payload: [${JSON.stringify(payload)}]`);
+  const compositeKey = generateCompositeKey(keys);
+  debug(`#setConsent compositeKey: [${compositeKey}]`);
+  await set(AUTH_SERVER_USER_CONSENTS_COLLECTION, payload, compositeKey);
+};
+
+const consentPayload = async (compositeKey) => get(AUTH_SERVER_USER_CONSENTS_COLLECTION, compositeKey);
+
+const consent = async (keys) => {
+  const compositeKey = generateCompositeKey(keys);
+  const payload = await consentPayload(compositeKey);
+  debug(`consent#id (compositeKey): ${compositeKey}`);
+  debug(`consent#payload: ${JSON.stringify(payload)}`);
+  if (!payload) {
+    const err = new Error(`consent for id ${JSON.stringify(keys)} not found`);
+    err.status = 500;
+    throw err;
+  }
+  return payload;
+};
+
+
+exports.generateCompositeKey = generateCompositeKey;
+exports.setConsent = setConsent;
+exports.consent = consent;
+exports.AUTH_SERVER_USER_CONSENTS_COLLECTION = AUTH_SERVER_USER_CONSENTS_COLLECTION;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,6 +1,7 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const { setTokenPayload, accessToken } = require('./access-tokens');
+const { setConsent, consent } = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
 const { accessTokenAndResourcePath } = require('./setup-request');
@@ -13,3 +14,5 @@ exports.createJsonWebSignature = createJsonWebSignature;
 exports.generateRedirectUri = generateRedirectUri;
 exports.createAccessToken = createAccessToken;
 exports.setTokenPayload = setTokenPayload;
+exports.setConsent = setConsent;
+exports.consent = consent;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,7 +1,7 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const { setTokenPayload, accessToken } = require('./access-tokens');
-const { setConsent, consent } = require('./consents');
+const { setConsent, consent, consentAccessToken } = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
 const { accessTokenAndResourcePath } = require('./setup-request');
@@ -16,3 +16,4 @@ exports.createAccessToken = createAccessToken;
 exports.setTokenPayload = setTokenPayload;
 exports.setConsent = setConsent;
 exports.consent = consent;
+exports.consentAccessToken = consentAccessToken;

--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -14,6 +14,7 @@ const resourceRequestHandler = async (req, res) => {
 
   const sessionId = req.headers.authorization;
   let host;
+  let accessToken;
   try {
     host = await resourceServerPath(authServerId);
   } catch (err) {
@@ -25,8 +26,12 @@ const resourceRequestHandler = async (req, res) => {
   const sessionData = JSON.parse(await session.getDataAsync(sessionId));
   const { username } = sessionData;
   const scope = path.split('/')[3];
-  const consentKeys = { username, authorisationServerId: authServerId, scope };
-  const accessToken = await consentAccessToken(consentKeys);
+  try {
+    const consentKeys = { username, authorisationServerId: authServerId, scope };
+    accessToken = await consentAccessToken(consentKeys);
+  } catch (err) {
+    accessToken = null;
+  }
   const bearerToken = `Bearer ${accessToken}`;
 
   debug(`proxiedUrl: ${proxiedUrl}`);

--- a/test/authorise/authorisation-code-granted.test.js
+++ b/test/authorise/authorisation-code-granted.test.js
@@ -13,7 +13,7 @@ const authorisationCode = '12345_67xxx';
 const sessionId = 'testSession';
 const username = 'testUser';
 const scope = 'accounts';
-const accountRequestId = 'testAccountRequestId'
+const accountRequestId = 'testAccountRequestId';
 
 const tokenRequestPayload = {
   grant_type: 'authorization_code', // eslint-disable-line quote-props
@@ -30,6 +30,7 @@ describe('Authorized Code Granted', () => {
   let redirection;
   let postTokenStub;
   let setTokenPayloadStub;
+  let setConsentStub;
   let getClientCredentialsStub;
   let sessionGetDataStub;
   let request;
@@ -98,7 +99,7 @@ describe('Authorized Code Granted', () => {
 
     it('calls setConsent to store obtained consent', async () => {
       await redirection.authorisationCodeGrantedHandler(request, response);
-      const args = setConsentStub.getCalls()[0].args;
+      const { args } = setConsentStub.getCalls()[0];
       assert.deepEqual({ username, authorisationServerId, scope }, args[0]);
       assert.deepEqual(
         {
@@ -110,7 +111,8 @@ describe('Authorized Code Granted', () => {
           authorisationCode,
           token: tokenResponsePayload,
         },
-        args[1]);
+        args[1],
+      );
     });
 
     describe('error handling', () => {

--- a/test/authorise/authorisation-code-granted.test.js
+++ b/test/authorise/authorisation-code-granted.test.js
@@ -12,6 +12,8 @@ const accessToken = 'access-token';
 const authorisationCode = '12345_67xxx';
 const sessionId = 'testSession';
 const username = 'testUser';
+const scope = 'accounts';
+const accountRequestId = 'testAccountRequestId'
 
 const tokenRequestPayload = {
   grant_type: 'authorization_code', // eslint-disable-line quote-props
@@ -35,6 +37,7 @@ describe('Authorized Code Granted', () => {
 
   beforeEach(() => {
     setTokenPayloadStub = sinon.stub();
+    setConsentStub = sinon.stub();
     postTokenStub = sinon.stub().returns(tokenResponsePayload);
     getClientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
     sessionGetDataStub = sinon.stub().returns(JSON.stringify({
@@ -50,6 +53,7 @@ describe('Authorized Code Granted', () => {
         getClientCredentials: getClientCredentialsStub,
       },
       './access-tokens': { setTokenPayload: setTokenPayloadStub },
+      './consents': { setConsent: setConsentStub },
       '../session': {
         session: {
           getDataAsync: sessionGetDataStub,
@@ -66,6 +70,8 @@ describe('Authorized Code Granted', () => {
       body: {
         authorisationCode,
         authorisationServerId,
+        scope,
+        accountRequestId,
       },
     });
     response = httpMocks.createResponse();
@@ -88,6 +94,23 @@ describe('Authorized Code Granted', () => {
         clientId, clientSecret, tokenRequestPayload,
       ));
       assert(setTokenPayloadStub.calledWithExactly(username, tokenResponsePayload));
+    });
+
+    it('calls setConsent to store obtained consent', async () => {
+      await redirection.authorisationCodeGrantedHandler(request, response);
+      const args = setConsentStub.getCalls()[0].args;
+      assert.deepEqual({ username, authorisationServerId, scope }, args[0]);
+      assert.deepEqual(
+        {
+          username,
+          authorisationServerId,
+          scope,
+          accountRequestId,
+          expirationDateTime: null,
+          authorisationCode,
+          token: tokenResponsePayload,
+        },
+        args[1]);
     });
 
     describe('error handling', () => {

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+const { setConsent, consent } = require('../../app/authorise');
+const { AUTH_SERVER_USER_CONSENTS_COLLECTION } = require('../../app/authorise/consents');
+
+const { drop } = require('../../app/storage.js');
+
+const username = 'testUsername';
+const authorisationServerId = 'a123';
+const scope = 'accounts';
+const keys = { username, authorisationServerId, scope };
+
+const accountRequestId = 'xxxxxx-xxxx-43c6-9c75-eaf01821375e';
+const authorisationCode = 'spoofAuthCode';
+const token = 'testAccessToken';
+const tokenPayload = {
+  access_token: token,
+  expires_in: 3600,
+  token_type : 'bearer',
+};
+
+const consentPayload = {
+  username,
+  authorisationServerId,
+  scope,
+  accountRequestId,
+  expirationDateTime: null,
+  authorisationCode,
+  token: tokenPayload,
+};
+
+describe('setConsents', () => {
+  beforeEach(async () => {
+    await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
+  });
+
+  afterEach(async () => {
+    await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
+  });
+
+  it('stores payload and allows consent to be retrieved', async () => {
+    await setConsent(keys, consentPayload);
+    const stored = await consent(keys);
+    assert.equal(stored.id, `${username}:::${authorisationServerId}:::${scope}`);
+    assert.equal(stored.token.access_token, token);
+  });
+});

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -16,7 +16,7 @@ const token = 'testAccessToken';
 const tokenPayload = {
   access_token: token,
   expires_in: 3600,
-  token_type : 'bearer',
+  token_type: 'bearer',
 };
 
 const consentPayload = {


### PR DESCRIPTION
This PR:
* Completes work on tracking a user's consent.
* It uses `access_token` related to a given consent.
* Its an end to end solution and works against proxied accounts endpoints.

Consent is indexed using a composite key that is a concatenated string made up of `username:::authorisationServerId:::scope`.