### PR TITLE
 Add accountsConsentGranted field to ASPSP list payload - REFAPP-191

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ jspm_packages
 .env.local
 .env.real
 swagger2markup-cli-1.3.1.jar
-
+/tmp
 *.idea/*

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -17,7 +17,7 @@ const sortByName = (list) => {
   return list;
 };
 
-const transformServerData = (data) => {
+const decorateServerDataForClient = (data) => {
   const id = data.Id;
   const logoUri = data.CustomerFriendlyLogoUri;
   const name = data.CustomerFriendlyName;
@@ -169,7 +169,7 @@ const authorisationServersForClient = async () => {
   try {
     const allServers = await allAuthorisationServers();
     const registeredServers = allServers.filter(s => s.clientCredentials);
-    const servers = registeredServers.map(s => transformServerData(s.obDirectoryConfig));
+    const servers = registeredServers.map(s => decorateServerDataForClient(s.obDirectoryConfig));
     return sortByName(servers);
   } catch (e) {
     error(e);

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -118,17 +118,21 @@ const allAuthorisationServers = async () => {
   }
 };
 
+const updateOpenIdConfig = async (id, openidConfig) => {
+  const authServer = await getAuthServerConfig(id);
+  debug(`openidConfig: ${JSON.stringify(openidConfig)}`);
+  authServer.openIdConfig = openidConfig;
+  await setAuthServerConfig(id, authServer);
+};
+
 const fetchAndStoreOpenIdConfig = async (id, openidConfigUrl) => {
   try {
     if (openidConfigUrl === 'https://redirect.openbanking.org.uk') {
       return null; // ignore
     }
     const openidConfig = await getOpenIdConfig(openidConfigUrl);
-    const authServer = await getAuthServerConfig(id);
     if (openidConfig) {
-      debug(`openidConfig: ${JSON.stringify(openidConfig)}`);
-      authServer.openIdConfig = openidConfig;
-      await setAuthServerConfig(id, authServer);
+      await updateOpenIdConfig(id, openidConfig);
     } else {
       error(`OpenID config at ${openidConfigUrl} is blank`);
     }
@@ -217,6 +221,7 @@ exports.tokenEndpoint = tokenEndpoint;
 exports.resourceServerHost = resourceServerHost;
 exports.resourceServerPath = resourceServerPath;
 exports.updateOpenIdConfigs = updateOpenIdConfigs;
+exports.updateOpenIdConfig = updateOpenIdConfig;
 exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;
 exports.setAuthServerConfig = setAuthServerConfig;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,7 +1,9 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const { setTokenPayload, accessToken } = require('./access-tokens');
-const { setConsent, consent, consentAccessToken } = require('./consents');
+const {
+  setConsent, consent, consentAccessToken, filterConsented,
+} = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
 const { accessTokenAndResourcePath } = require('./setup-request');
@@ -11,6 +13,7 @@ exports.accessTokenAndResourcePath = accessTokenAndResourcePath;
 exports.authorisationCodeGrantedHandler = authorisationCodeGrantedHandler;
 exports.createClaims = createClaims;
 exports.createJsonWebSignature = createJsonWebSignature;
+exports.filterConsented = filterConsented;
 exports.generateRedirectUri = generateRedirectUri;
 exports.createAccessToken = createAccessToken;
 exports.setTokenPayload = setTokenPayload;

--- a/app/index.js
+++ b/app/index.js
@@ -8,7 +8,7 @@ const { requireAuthorization } = require('./session');
 const { requireAuthorisationServerId } = require('./authorisation-servers');
 const { login } = require('./session');
 const { resourceRequestHandler } = require('./request-data/ob-proxy.js');
-const { OBAccountPaymentServiceProviders } = require('./ob-directory');
+const { accountPaymentServiceProviders } = require('./ob-directory');
 const { accountRequestAuthoriseConsent } = require('./setup-account-request');
 const { paymentAuthoriseConsent } = require('./setup-payment');
 const { paymentSubmission } = require('./submit-payment');
@@ -30,7 +30,7 @@ app.use('/logout', login.logout);
 app.all('/account-payment-service-provider-authorisation-servers', requireAuthorization);
 app.use(
   '/account-payment-service-provider-authorisation-servers',
-  OBAccountPaymentServiceProviders,
+  accountPaymentServiceProviders,
 );
 
 app.all('/account-request-authorise-consent', requireAuthorization, requireAuthorisationServerId);

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -11,6 +11,7 @@ const {
   authorisationServersForClient,
   storeAuthorisationServers,
 } = require('./authorisation-servers');
+const { filterConsented } = require('./authorise');
 
 const NOT_PROVISIONED_FOR_OB_TOKEN = 'NO_TOKEN';
 
@@ -112,9 +113,24 @@ const fetchOBAccountPaymentServiceProviders = async () => {
   }
 };
 
+const accountPaymentServiceProvidersForUser = async (username) => {
+  const servers = await authorisationServersForClient();
+  const authServerIds = servers.map(config => config.id);
+  const consentedServerIds = await filterConsented(username, 'accounts', authServerIds);
+
+  servers.forEach((config) => {
+    const hasConsent = consentedServerIds.includes(config.id);
+    Object.assign(config, { accountsConsentGranted: hasConsent });
+  });
+  return servers;
+};
+
 const accountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  const servers = await authorisationServersForClient();
+  const sessionId = req.headers.authorization;
+  const username = await session.getUsername(sessionId);
+  const servers = await accountPaymentServiceProvidersForUser(username);
+
   log(`servers length: ${servers.length}`);
   return res.json(servers);
 };

--- a/app/ob-directory.js
+++ b/app/ob-directory.js
@@ -112,7 +112,7 @@ const fetchOBAccountPaymentServiceProviders = async () => {
   }
 };
 
-const OBAccountPaymentServiceProviders = async (req, res) => {
+const accountPaymentServiceProviders = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   const servers = await authorisationServersForClient();
   log(`servers length: ${servers.length}`);
@@ -121,5 +121,5 @@ const OBAccountPaymentServiceProviders = async (req, res) => {
 
 exports.extractAuthorisationServers = extractAuthorisationServers;
 exports.fetchOBAccountPaymentServiceProviders = fetchOBAccountPaymentServiceProviders;
-exports.OBAccountPaymentServiceProviders = OBAccountPaymentServiceProviders;
+exports.accountPaymentServiceProviders = accountPaymentServiceProviders;
 exports.signingKey = signingKey;

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -216,3 +216,7 @@ describe('authorisation servers', () => {
     });
   });
 });
+
+exports.flattenedObDirectoryAuthServerList = flattenedObDirectoryAuthServerList;
+exports.clientCredentials = clientCredentials;
+exports.openIdConfig = openIdConfig;

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -51,18 +51,29 @@ describe('filterConsented', () => {
     await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
   });
 
-  describe('given auth server id with consent', () => {
+  describe('given authorisationServerId with authorisationCode in config', () => {
     beforeEach(async () => {
       await setConsent(keys, consentPayload);
     });
 
-    it('returns array containing that auth server id', async () => {
+    it('returns array containing authorisationServerId', async () => {
       const consented = await filterConsented(username, scope, [authorisationServerId]);
       assert.deepEqual(consented, [authorisationServerId]);
     });
   });
 
-  describe('given auth server id without consent', () => {
+  describe('given authorisationServerId with no authorisationCode in config', () => {
+    beforeEach(async () => {
+      await setConsent(keys, Object.assign(consentPayload, { authorisationCode: null }));
+    });
+
+    it('returns empty array', async () => {
+      const consented = await filterConsented(username, scope, [authorisationServerId]);
+      assert.deepEqual(consented, []);
+    });
+  });
+
+  describe('given authorisationServerId without config', () => {
     it('returns empty array', async () => {
       const consented = await filterConsented(username, scope, [authorisationServerId]);
       assert.deepEqual(consented, []);

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const { setConsent, consent } = require('../../app/authorise');
+const { setConsent, consent, filterConsented } = require('../../app/authorise');
 const { AUTH_SERVER_USER_CONSENTS_COLLECTION } = require('../../app/authorise/consents');
 
 const { drop } = require('../../app/storage.js');
@@ -43,5 +43,29 @@ describe('setConsents', () => {
     const stored = await consent(keys);
     assert.equal(stored.id, `${username}:::${authorisationServerId}:::${scope}`);
     assert.equal(stored.token.access_token, token);
+  });
+});
+
+describe('filterConsented', () => {
+  afterEach(async () => {
+    await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
+  });
+
+  describe('given auth server id with consent', () => {
+    beforeEach(async () => {
+      await setConsent(keys, consentPayload);
+    });
+
+    it('returns array containing that auth server id', async () => {
+      const consented = await filterConsented(username, scope, [authorisationServerId]);
+      assert.deepEqual(consented, [authorisationServerId]);
+    });
+  });
+
+  describe('given auth server id without consent', () => {
+    it('returns empty array', async () => {
+      const consented = await filterConsented(username, scope, [authorisationServerId]);
+      assert.deepEqual(consented, []);
+    });
   });
 });


### PR DESCRIPTION
- Add `filterConsented` function to filter auth server ids that user has consent with for given scope.
- Add `accountsConsentGranted` field to ASPSP list payload, to be used by client.

Note: Ignores `expirationDateTime` for now when determining consent is present. To be added in a future PR.
