### PR TITLE
Add revoke accounts consent endpoint REFAPP-201

### DIFF
--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -28,8 +28,8 @@ const setConsent = async (keys, payload) => {
   await set(AUTH_SERVER_USER_CONSENTS_COLLECTION, payload, compositeKey);
 };
 
-const removeAuthServerUserConsent = async (keys) => {
-  debug(`#removeAuthServerUserConsent keys: [${JSON.stringify(keys)}]`);
+const deleteConsent = async (keys) => {
+  debug(`#deleteConsent keys: [${JSON.stringify(keys)}]`);
   const compositeKey = generateCompositeKey(keys);
   await remove(AUTH_SERVER_USER_CONSENTS_COLLECTION, compositeKey);
 };
@@ -116,10 +116,11 @@ const consentAccountRequestId = async (keys) => {
 
 exports.generateCompositeKey = generateCompositeKey;
 exports.setConsent = setConsent;
+exports.getConsent = getConsent;
 exports.consent = consent;
 exports.consentAccessToken = consentAccessToken;
 exports.filterConsented = filterConsented;
 exports.getConsentStatus = getConsentStatus;
 exports.consentAccountRequestId = consentAccountRequestId;
-exports.removeAuthServerUserConsent = removeAuthServerUserConsent;
+exports.deleteConsent = deleteConsent;
 exports.AUTH_SERVER_USER_CONSENTS_COLLECTION = AUTH_SERVER_USER_CONSENTS_COLLECTION;

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -103,10 +103,16 @@ const filterConsented = async (username, scope, authorisationServerIds) => {
   return consented;
 };
 
+const consentAccountRequestId = async (keys) => {
+  const existing = await consent(keys);
+  return existing.accountRequestId;
+};
+
 exports.generateCompositeKey = generateCompositeKey;
 exports.setConsent = setConsent;
 exports.consent = consent;
 exports.consentAccessToken = consentAccessToken;
 exports.filterConsented = filterConsented;
 exports.getConsentStatus = getConsentStatus;
+exports.consentAccountRequestId = consentAccountRequestId;
 exports.AUTH_SERVER_USER_CONSENTS_COLLECTION = AUTH_SERVER_USER_CONSENTS_COLLECTION;

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -1,4 +1,4 @@
-const { get, set } = require('../storage');
+const { get, set, remove } = require('../storage');
 const { accessTokenAndResourcePath } = require('./setup-request');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
 const { getAccountRequest } = require('../setup-account-request/account-requests');
@@ -26,6 +26,12 @@ const setConsent = async (keys, payload) => {
   const compositeKey = generateCompositeKey(keys);
   debug(`#setConsent compositeKey: [${compositeKey}]`);
   await set(AUTH_SERVER_USER_CONSENTS_COLLECTION, payload, compositeKey);
+};
+
+const removeAuthServerUserConsent = async (keys) => {
+  debug(`#removeAuthServerUserConsent keys: [${JSON.stringify(keys)}]`);
+  const compositeKey = generateCompositeKey(keys);
+  await remove(AUTH_SERVER_USER_CONSENTS_COLLECTION, compositeKey);
 };
 
 const consentPayload = async compositeKey =>
@@ -115,4 +121,5 @@ exports.consentAccessToken = consentAccessToken;
 exports.filterConsented = filterConsented;
 exports.getConsentStatus = getConsentStatus;
 exports.consentAccountRequestId = consentAccountRequestId;
+exports.removeAuthServerUserConsent = removeAuthServerUserConsent;
 exports.AUTH_SERVER_USER_CONSENTS_COLLECTION = AUTH_SERVER_USER_CONSENTS_COLLECTION;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,7 +1,12 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const {
-  setConsent, consent, consentAccessToken, filterConsented, consentAccountRequestId,
+  setConsent,
+  consent,
+  consentAccessToken,
+  filterConsented,
+  consentAccountRequestId,
+  removeAuthServerUserConsent,
 } = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
@@ -18,3 +23,4 @@ exports.setConsent = setConsent;
 exports.consent = consent;
 exports.consentAccountRequestId = consentAccountRequestId;
 exports.consentAccessToken = consentAccessToken;
+exports.removeAuthServerUserConsent = removeAuthServerUserConsent;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -2,11 +2,12 @@ const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const {
   setConsent,
+  getConsent,
   consent,
   consentAccessToken,
   filterConsented,
   consentAccountRequestId,
-  removeAuthServerUserConsent,
+  deleteConsent,
 } = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
@@ -20,7 +21,8 @@ exports.filterConsented = filterConsented;
 exports.generateRedirectUri = generateRedirectUri;
 exports.createAccessToken = createAccessToken;
 exports.setConsent = setConsent;
+exports.getConsent = getConsent;
 exports.consent = consent;
 exports.consentAccountRequestId = consentAccountRequestId;
 exports.consentAccessToken = consentAccessToken;
-exports.removeAuthServerUserConsent = removeAuthServerUserConsent;
+exports.deleteConsent = deleteConsent;

--- a/app/authorise/index.js
+++ b/app/authorise/index.js
@@ -1,7 +1,7 @@
 const { createClaims, createJsonWebSignature } = require('./request-jws');
 const { generateRedirectUri } = require('./authorise-uri');
 const {
-  setConsent, consent, consentAccessToken, filterConsented,
+  setConsent, consent, consentAccessToken, filterConsented, consentAccountRequestId,
 } = require('./consents');
 const { authorisationCodeGrantedHandler } = require('./authorisation-code-granted');
 const { createAccessToken } = require('./obtain-access-token');
@@ -16,4 +16,5 @@ exports.generateRedirectUri = generateRedirectUri;
 exports.createAccessToken = createAccessToken;
 exports.setConsent = setConsent;
 exports.consent = consent;
+exports.consentAccountRequestId = consentAccountRequestId;
 exports.consentAccessToken = consentAccessToken;

--- a/app/index.js
+++ b/app/index.js
@@ -9,7 +9,7 @@ const { requireAuthorisationServerId } = require('./authorisation-servers');
 const { login } = require('./session');
 const { resourceRequestHandler } = require('./request-data/ob-proxy.js');
 const { accountPaymentServiceProviders } = require('./ob-directory');
-const { accountRequestAuthoriseConsent } = require('./setup-account-request');
+const { accountRequestAuthoriseConsent, accountRequestRevokeConsent } = require('./setup-account-request');
 const { paymentAuthoriseConsent } = require('./setup-payment');
 const { paymentSubmission } = require('./submit-payment');
 const { authorisationCodeGrantedHandler } = require('./authorise');
@@ -35,6 +35,9 @@ app.use(
 
 app.all('/account-request-authorise-consent', requireAuthorization, requireAuthorisationServerId);
 app.post('/account-request-authorise-consent', accountRequestAuthoriseConsent);
+
+app.all('/account-request-revoke-consent', requireAuthorization, requireAuthorisationServerId);
+app.post('/account-request-revoke-consent', accountRequestRevokeConsent);
 
 app.all('/payment-authorise-consent', requireAuthorization, requireAuthorisationServerId);
 app.post('/payment-authorise-consent', paymentAuthoriseConsent);

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -36,7 +36,10 @@ const accountRequestRevokeConsent = async (req, res) => {
     const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
     debug(`In accountRequestRevokeConsent authorisationServerId: ${authorisationServerId}`);
     const interactionId = uuidv4();
-    const status = deleteRequest(sessionId, authorisationServerId, fapiFinancialId, interactionId);
+    const status = await deleteRequest(
+      sessionId, authorisationServerId,
+      fapiFinancialId, interactionId,
+    );
     return res.sendStatus(status);
   } catch (err) {
     return res.sendStatus(400);

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -1,4 +1,4 @@
-const { setupAccountRequest } = require('./setup-account-request');
+const { setupAccountRequest, deleteRequest } = require('./setup-account-request');
 const { generateRedirectUri } = require('../authorise');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
 
@@ -28,4 +28,21 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   }
 };
 
+const accountRequestRevokeConsent = async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  try {
+    const sessionId = req.headers['authorization'];
+    const authorisationServerId = req.headers['x-authorization-server-id'];
+    const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
+    debug(`In accountRequestRevokeConsent authorisationServerId: ${authorisationServerId}`);
+    const interactionId = uuidv4();
+    const status = deleteRequest(sessionId, authorisationServerId, fapiFinancialId, interactionId);
+    return res.sendStatus(status);
+  } catch (err) {
+    return res.sendStatus(400);
+  }
+};
+
+
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
+exports.accountRequestRevokeConsent = accountRequestRevokeConsent;

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -1,6 +1,8 @@
-const { setupAccountRequest, deleteRequest } = require('./setup-account-request');
+const { setupAccountRequest } = require('./setup-account-request');
+const { deleteRequest } = require('./delete-account-request');
 const { generateRedirectUri } = require('../authorise');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
+const { session } = require('../session');
 
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
@@ -32,20 +34,18 @@ const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const sessionId = req.headers['authorization'];
+    const username = await session.getUsername(sessionId);
     const authorisationServerId = req.headers['x-authorization-server-id'];
     const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
     debug(`In accountRequestRevokeConsent authorisationServerId: ${authorisationServerId}`);
     const interactionId = uuidv4();
-    const status = await deleteRequest(
-      sessionId, authorisationServerId,
-      fapiFinancialId, interactionId,
-    );
+    const headers = { fapiFinancialId, interactionId };
+    const status = await deleteRequest(username, authorisationServerId, headers);
     return res.sendStatus(status);
   } catch (err) {
     return res.sendStatus(400);
   }
 };
-
 
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
 exports.accountRequestRevokeConsent = accountRequestRevokeConsent;

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -16,10 +16,12 @@ const accountRequestAuthoriseConsent = async (req, res) => {
     const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
 
     debug(`authorisationServerId: ${authorisationServerId}`);
-    const accountRequestId = await setupAccountRequest(authorisationServerId, fapiFinancialId);
     const interactionId = uuidv4();
+    const headers = { fapiFinancialId, interactionId };
+    const accountRequestId = await setupAccountRequest(authorisationServerId, headers);
 
-    const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', sessionId, interactionId);
+    const interactionId2 = uuidv4();
+    const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', sessionId, interactionId2);
 
     debug(`authorize URL is: ${uri}`);
     return res.status(200).send({ uri }); // We can't intercept a 302 !

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -75,6 +75,38 @@ const getAccountRequest = async (
   }
 };
 
+const deleteAccountRequest = async (
+  resourceServerPath,
+  accessToken,
+  fapiFinancialId,
+  accountRequestId,
+  fapiInteractionId,
+) => {
+  try {
+    const accountRequestDeleteUri = `${resourceServerPath}/open-banking/v1.1/account-requests/${accountRequestId}`;
+    log(`DELETE to ${accountRequestDeleteUri}`);
+    const response = await setupMutualTLS(request.del(accountRequestDeleteUri))
+      .set('authorization', `Bearer ${accessToken}`)
+      .set('content-type', 'application/json; charset=utf-8')
+      .set('accept', 'application/json; charset=utf-8')
+      .set('x-fapi-financial-id', fapiFinancialId)
+      .set('x-fapi-interaction-id', fapiInteractionId)
+      .send();
+    debug(`${response.status} response for ${accountRequestDeleteUri}`);
+    if (response.status.toString() === '204') {
+      return response.headers;
+    }
+    const error = new Error('Bad Request');
+    error.status = 400;
+    throw error;
+  } catch (err) {
+    const error = new Error(err.message);
+    error.status = err.response ? err.response.status : 400;
+    throw error;
+  }
+};
+
 exports.buildAccountRequestData = buildAccountRequestData;
 exports.postAccountRequests = postAccountRequests;
 exports.getAccountRequest = getAccountRequest;
+exports.deleteAccountRequest = deleteAccountRequest;

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -23,6 +23,8 @@ const buildAccountRequestData = () => ({
   Risk: {},
 });
 
+const APPLICATION_JSON = 'application/json; charset=utf-8';
+
 /*
  * For now only support Client Credentials Grant Type (OAuth 2.0).
  * @resourceServerPath e.g. http://example.com/open-banking/v1.1
@@ -35,8 +37,8 @@ const postAccountRequests = async (resourceServerPath, accessToken,
     log(`POST to ${accountRequestsUri}`);
     const response = await setupMutualTLS(request.post(accountRequestsUri))
       .set('authorization', `Bearer ${accessToken}`)
-      .set('content-type', 'application/json; charset=utf-8')
-      .set('accept', 'application/json; charset=utf-8')
+      .set('content-type', APPLICATION_JSON)
+      .set('accept', APPLICATION_JSON)
       .set('x-fapi-financial-id', fapiFinancialId)
       .send(body);
     debug(`${response.status} response for ${accountRequestsUri}`);
@@ -87,14 +89,14 @@ const deleteAccountRequest = async (
     log(`DELETE to ${accountRequestDeleteUri}`);
     const response = await setupMutualTLS(request.del(accountRequestDeleteUri))
       .set('authorization', `Bearer ${accessToken}`)
-      .set('content-type', 'application/json; charset=utf-8')
-      .set('accept', 'application/json; charset=utf-8')
+      .set('content-type', APPLICATION_JSON)
+      .set('accept', APPLICATION_JSON)
       .set('x-fapi-financial-id', fapiFinancialId)
       .set('x-fapi-interaction-id', fapiInteractionId)
       .send();
     debug(`${response.status} response for ${accountRequestDeleteUri}`);
-    if (response.status.toString() === '204') {
-      return response.headers;
+    if (response.status === 204) {
+      return true;
     }
     const error = new Error('Bad Request');
     error.status = 400;

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -84,22 +84,17 @@ const getAccountRequest = async (
   }
 };
 
-const deleteAccountRequest = async (
-  resourceServerPath,
-  accessToken,
-  fapiFinancialId,
-  accountRequestId,
-  fapiInteractionId,
-) => {
+const deleteAccountRequest = async (accountRequestId, resourceServerPath, headers) => {
   try {
+    verifyHeaders(headers);
     const accountRequestDeleteUri = `${resourceServerPath}/open-banking/v1.1/account-requests/${accountRequestId}`;
     log(`DELETE to ${accountRequestDeleteUri}`);
     const response = await setupMutualTLS(request.del(accountRequestDeleteUri))
-      .set('authorization', `Bearer ${accessToken}`)
+      .set('authorization', `Bearer ${headers.accessToken}`)
       .set('content-type', APPLICATION_JSON)
       .set('accept', APPLICATION_JSON)
-      .set('x-fapi-financial-id', fapiFinancialId)
-      .set('x-fapi-interaction-id', fapiInteractionId)
+      .set('x-fapi-financial-id', headers.fapiFinancialId)
+      .set('x-fapi-interaction-id', headers.interactionId)
       .send();
     debug(`${response.status} response for ${accountRequestDeleteUri}`);
     if (response.status === 204) {

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -29,7 +29,7 @@ const APPLICATION_JSON = 'application/json; charset=utf-8';
 const verifyHeaders = (headers) => {
   assert.ok(headers.accessToken, 'accessToken missing from headers');
   assert.ok(headers.fapiFinancialId, 'fapiFinancialId missing from headers');
-  // assert.ok(headers.interactionId, 'interactionId missing from headers');
+  assert.ok(headers.interactionId, 'interactionId missing from headers');
 };
 
 /*

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -1,0 +1,21 @@
+const { accessTokenAndResourcePath, consentAccountRequestId, removeAuthServerUserConsent } = require('../authorise');
+const { deleteAccountRequest } = require('./account-requests');
+
+const deleteRequest = async (username, authorisationServerId, headers) => {
+  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
+  const headersWithToken = Object.assign(headers, { accessToken });
+  const keys = { username, authorisationServerId, scope: 'accounts' };
+  const accountRequestId = await consentAccountRequestId(keys);
+  if (accountRequestId) {
+    const success = await deleteAccountRequest(accountRequestId, resourcePath, headersWithToken);
+    if (success) {
+      await removeAuthServerUserConsent(keys);
+      return 204;
+    }
+  }
+  const error = new Error('Bad Request');
+  error.status = 400;
+  throw error;
+};
+
+exports.deleteRequest = deleteRequest;

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -1,4 +1,4 @@
-const { accessTokenAndResourcePath, consentAccountRequestId, removeAuthServerUserConsent } = require('../authorise');
+const { accessTokenAndResourcePath, consentAccountRequestId, deleteConsent } = require('../authorise');
 const { deleteAccountRequest } = require('./account-requests');
 
 const deleteRequest = async (username, authorisationServerId, headers) => {
@@ -9,7 +9,7 @@ const deleteRequest = async (username, authorisationServerId, headers) => {
   if (accountRequestId) {
     const success = await deleteAccountRequest(accountRequestId, resourcePath, headersWithToken);
     if (success) {
-      await removeAuthServerUserConsent(keys);
+      await deleteConsent(keys);
       return 204;
     }
   }

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -2,11 +2,12 @@ const { accessTokenAndResourcePath, consentAccountRequestId, deleteConsent } = r
 const { deleteAccountRequest } = require('./account-requests');
 
 const deleteRequest = async (username, authorisationServerId, headers) => {
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
-  const headersWithToken = Object.assign(headers, { accessToken });
   const keys = { username, authorisationServerId, scope: 'accounts' };
   const accountRequestId = await consentAccountRequestId(keys);
+
   if (accountRequestId) {
+    const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
+    const headersWithToken = Object.assign(headers, { accessToken });
     const success = await deleteAccountRequest(accountRequestId, resourcePath, headersWithToken);
     if (success) {
       await deleteConsent(keys);

--- a/app/setup-account-request/index.js
+++ b/app/setup-account-request/index.js
@@ -1,8 +1,11 @@
-const { accountRequestAuthoriseConsent, statePayload, generateRedirectUri } = require('./account-request-authorise-consent');
+const {
+  accountRequestAuthoriseConsent, accountRequestRevokeConsent, statePayload, generateRedirectUri,
+} = require('./account-request-authorise-consent');
 const { setupAccountRequest } = require('./setup-account-request');
 const { getAccountRequest } = require('./account-requests');
 
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
+exports.accountRequestRevokeConsent = accountRequestRevokeConsent;
 exports.setupAccountRequest = setupAccountRequest;
 exports.statePayload = statePayload;
 exports.generateRedirectUri = generateRedirectUri;

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,6 +1,6 @@
 const { accessTokenAndResourcePath, consentAccountRequestId } = require('../authorise');
 const { postAccountRequests, deleteAccountRequest } = require('./account-requests');
-const { getUsername } = require('../session/session');
+const { session } = require('../session');
 
 const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
   const response = await postAccountRequests(resourcePath, accessToken, fapiFinancialId);
@@ -34,10 +34,10 @@ const deleteRequest = async (
     error.status = 400;
     throw error;
   };
-  const username = await getUsername(sessionId);
+  const username = await session.getUsername(sessionId);
   const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
   const keys = { username, authorisationServerId, scope: 'accounts' };
-  const accountRequestId = consentAccountRequestId(keys);
+  const accountRequestId = await consentAccountRequestId(keys);
   if (!accountRequestId) return fail();
   const responseHeaders = await deleteAccountRequest(
     resourcePath,

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,4 +1,4 @@
-const { accessTokenAndResourcePath, consentAccountRequestId } = require('../authorise');
+const { accessTokenAndResourcePath, consentAccountRequestId, removeAuthServerUserConsent } = require('../authorise');
 const { postAccountRequests, deleteAccountRequest } = require('./account-requests');
 const { session } = require('../session');
 
@@ -49,6 +49,7 @@ const deleteRequest = async (
   if (responseHeaders) {
     const interactionId = responseHeaders['x-fapi-interaction-id'];
     if (fapiInteractionId === interactionId) {
+      await removeAuthServerUserConsent(keys);
       return 204;
     }
     return fail();

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,8 +1,7 @@
 const { accessTokenAndResourcePath } = require('../authorise');
 const { postAccountRequests } = require('./account-requests');
 
-const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
-  const headers = { accessToken, fapiFinancialId };
+const createRequest = async (resourcePath, headers) => {
   const response = await postAccountRequests(resourcePath, headers);
   let error;
   if (response.Data) {
@@ -22,13 +21,10 @@ const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
   throw error;
 };
 
-const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
+const setupAccountRequest = async (authorisationServerId, headers) => {
   const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
-  const accountRequestId = await createRequest(
-    resourcePath,
-    accessToken,
-    fapiFinancialId,
-  );
+  const headersWithToken = Object.assign(headers, { accessToken });
+  const accountRequestId = await createRequest(resourcePath, headersWithToken);
   return accountRequestId;
 };
 

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -3,7 +3,8 @@ const { postAccountRequests, deleteAccountRequest } = require('./account-request
 const { session } = require('../session');
 
 const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
-  const response = await postAccountRequests(resourcePath, accessToken, fapiFinancialId);
+  const headers = { accessToken, fapiFinancialId };
+  const response = await postAccountRequests(resourcePath, headers);
   let error;
   if (response.Data) {
     const status = response.Data.Status;

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -1,6 +1,5 @@
-const { accessTokenAndResourcePath, consentAccountRequestId, removeAuthServerUserConsent } = require('../authorise');
-const { postAccountRequests, deleteAccountRequest } = require('./account-requests');
-const { session } = require('../session');
+const { accessTokenAndResourcePath } = require('../authorise');
+const { postAccountRequests } = require('./account-requests');
 
 const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
   const headers = { accessToken, fapiFinancialId };
@@ -23,42 +22,6 @@ const createRequest = async (resourcePath, accessToken, fapiFinancialId) => {
   throw error;
 };
 
-
-const deleteRequest = async (
-  sessionId,
-  authorisationServerId,
-  fapiFinancialId,
-  fapiInteractionId,
-) => {
-  const fail = () => {
-    const error = new Error('Bad Request');
-    error.status = 400;
-    throw error;
-  };
-  const username = await session.getUsername(sessionId);
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
-  const keys = { username, authorisationServerId, scope: 'accounts' };
-  const accountRequestId = await consentAccountRequestId(keys);
-  if (!accountRequestId) return fail();
-  const responseHeaders = await deleteAccountRequest(
-    resourcePath,
-    accessToken,
-    fapiFinancialId,
-    accountRequestId,
-    fapiInteractionId,
-  );
-  if (responseHeaders) {
-    const interactionId = responseHeaders['x-fapi-interaction-id'];
-    if (fapiInteractionId === interactionId) {
-      await removeAuthServerUserConsent(keys);
-      return 204;
-    }
-    return fail();
-  }
-  return fail();
-};
-
-
 const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
   const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
   const accountRequestId = await createRequest(
@@ -70,4 +33,3 @@ const setupAccountRequest = async (authorisationServerId, fapiFinancialId) => {
 };
 
 exports.setupAccountRequest = setupAccountRequest;
-exports.deleteRequest = deleteRequest;

--- a/app/storage.js
+++ b/app/storage.js
@@ -75,6 +75,22 @@ const drop = async (collection) => {
   }
 };
 
+/**
+ * Remove document with given id from collection
+ * @param collection
+ * @param id
+ * @returns {Promise.<*>}
+ */
+const remove = async (collection, id) => {
+  try {
+    const store = await db.get(collection);
+    return await store.remove({ id });
+  } catch (e) {
+    error(e);
+    throw e;
+  }
+};
+
 const close = async () => {
   try {
     await db.close();
@@ -87,4 +103,5 @@ exports.get = get;
 exports.getAll = getAll;
 exports.set = set;
 exports.drop = drop;
+exports.remove = remove;
 exports.close = close;

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -3,7 +3,12 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 const {
-  setConsent, consent, consentAccessToken, consentAccountRequestId,
+  setConsent,
+  consent,
+  consentAccessToken,
+  consentAccountRequestId,
+  deleteConsent,
+  getConsent,
 } = require('../../app/authorise');
 const { AUTH_SERVER_USER_CONSENTS_COLLECTION } = require('../../app/authorise/consents');
 
@@ -60,6 +65,23 @@ describe('setConsents', () => {
     await setConsent(keys, consentPayload);
     const storedAccountRequestId = await consentAccountRequestId(keys);
     assert.equal(storedAccountRequestId, accountRequestId);
+  });
+});
+
+describe('deleteConsent', () => {
+  beforeEach(async () => {
+    await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
+  });
+
+  afterEach(async () => {
+    await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
+  });
+
+  it('stores payload and allows consent to be retrieved by keys id', async () => {
+    await setConsent(keys, consentPayload);
+    await deleteConsent(keys);
+    const result = await getConsent(keys);
+    assert.equal(result, null);
   });
 });
 

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -3,8 +3,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 const {
-  setConsent,
-  consent,
+  setConsent, consent, consentAccessToken, consentAccountRequestId,
 } = require('../../app/authorise');
 const { AUTH_SERVER_USER_CONSENTS_COLLECTION } = require('../../app/authorise/consents');
 
@@ -45,11 +44,22 @@ describe('setConsents', () => {
     await drop(AUTH_SERVER_USER_CONSENTS_COLLECTION);
   });
 
-  it('stores payload and allows consent to be retrieved', async () => {
+  it('stores payload and allows consent to be retrieved by keys id', async () => {
     await setConsent(keys, consentPayload);
     const stored = await consent(keys);
     assert.equal(stored.id, `${username}:::${authorisationServerId}:::${scope}`);
-    assert.equal(stored.token.access_token, token);
+  });
+
+  it('stores payload and allows consent access_token to be retrieved', async () => {
+    await setConsent(keys, consentPayload);
+    const storedAccessToken = await consentAccessToken(keys);
+    assert.equal(storedAccessToken, token);
+  });
+
+  it('stores payload and allows consent accountRequestId to be retrieved', async () => {
+    await setConsent(keys, consentPayload);
+    const storedAccountRequestId = await consentAccountRequestId(keys);
+    assert.equal(storedAccountRequestId, accountRequestId);
   });
 });
 

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -120,7 +120,10 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
         assert.deepEqual(params, expectedParams);
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        assert(setupAccountRequestStub.calledWithExactly(authorisationServerId, fapiFinancialId));
+        assert(setupAccountRequestStub.calledWithExactly(
+          authorisationServerId,
+          { fapiFinancialId, interactionId },
+        ));
         done();
       });
   });
@@ -142,7 +145,10 @@ describe('/account-request-authorise-consent with error thrown by setupAccountRe
         assert.deepEqual(r.body, { message });
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        assert(setupAccountRequestStub.calledWithExactly(authorisationServerId, fapiFinancialId));
+        assert(setupAccountRequestStub.calledWithExactly(
+          authorisationServerId,
+          { fapiFinancialId, interactionId },
+        ));
         done();
       });
   });

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -1,4 +1,5 @@
 const {
+  deleteAccountRequest,
   postAccountRequests,
   getAccountRequest,
   buildAccountRequestData,
@@ -27,6 +28,7 @@ const response = {
 
 const accessToken = '2YotnFZFEjr1zCsicMWpAA';
 const fapiFinancialId = 'abc';
+const fapiInteractionId = 'xyz';
 
 describe('postAccountRequests', () => {
   nock(/example\.com/)
@@ -70,5 +72,29 @@ describe('getAccountRequest', () => {
       fapiFinancialId,
     );
     assert.deepEqual(result, response);
+  });
+});
+
+describe('deleteAccountRequest', () => {
+  nock(/example\.com/)
+    .delete(`/prefix/open-banking/v1.1/account-requests/${accountRequestId}`)
+    .matchHeader('authorization', `Bearer ${accessToken}`) // required
+    .matchHeader('x-fapi-financial-id', fapiFinancialId) // required
+    .matchHeader('x-fapi-interaction-id', fapiInteractionId) // required
+    // optional x-jws-signature
+    // optional x-fapi-customer-last-logged-time
+    // optional x-fapi-customer-ip-address
+    .reply(204);
+
+  it('returns true when 204 No Content', async () => {
+    const resourceServerPath = 'http://example.com/prefix';
+    const result = await deleteAccountRequest(
+      resourceServerPath,
+      accessToken,
+      fapiFinancialId,
+      accountRequestId,
+      fapiInteractionId,
+    );
+    assert.deepEqual(result, true);
   });
 });

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -28,7 +28,7 @@ const response = {
 
 const accessToken = '2YotnFZFEjr1zCsicMWpAA';
 const fapiFinancialId = 'abc';
-const fapiInteractionId = 'xyz';
+const interactionId = 'xyz';
 
 describe('postAccountRequests', () => {
   nock(/example\.com/)
@@ -77,7 +77,7 @@ describe('deleteAccountRequest', () => {
     .delete(`/prefix/open-banking/v1.1/account-requests/${accountRequestId}`)
     .matchHeader('authorization', `Bearer ${accessToken}`) // required
     .matchHeader('x-fapi-financial-id', fapiFinancialId) // required
-    .matchHeader('x-fapi-interaction-id', fapiInteractionId) // required
+    .matchHeader('x-fapi-interaction-id', interactionId) // required
     // optional x-jws-signature
     // optional x-fapi-customer-last-logged-time
     // optional x-fapi-customer-ip-address
@@ -85,13 +85,8 @@ describe('deleteAccountRequest', () => {
 
   it('returns true when 204 No Content', async () => {
     const resourceServerPath = 'http://example.com/prefix';
-    const result = await deleteAccountRequest(
-      resourceServerPath,
-      accessToken,
-      fapiFinancialId,
-      accountRequestId,
-      fapiInteractionId,
-    );
+    const headers = { accessToken, fapiFinancialId, interactionId };
+    const result = await deleteAccountRequest(accountRequestId, resourceServerPath, headers);
     assert.deepEqual(result, true);
   });
 });

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -43,11 +43,8 @@ describe('postAccountRequests', () => {
 
   it('returns data when 201 OK', async () => {
     const resourceServerPath = 'http://example.com/prefix';
-    const result = await postAccountRequests(
-      resourceServerPath,
-      accessToken,
-      fapiFinancialId,
-    );
+    const headers = { accessToken, fapiFinancialId };
+    const result = await postAccountRequests(resourceServerPath, headers);
     assert.deepEqual(result, response);
   });
 });

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -43,7 +43,7 @@ describe('postAccountRequests', () => {
 
   it('returns data when 201 OK', async () => {
     const resourceServerPath = 'http://example.com/prefix';
-    const headers = { accessToken, fapiFinancialId };
+    const headers = { accessToken, fapiFinancialId, interactionId };
     const result = await postAccountRequests(resourceServerPath, headers);
     assert.deepEqual(result, response);
   });

--- a/test/setup-account-request/delete-account-request.test.js
+++ b/test/setup-account-request/delete-account-request.test.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const { checkErrorThrown } = require('../utils');
+
+const authorisationServerId = 'testAuthorisationServerId';
+const fapiFinancialId = 'testFinancialId';
+const interactionId = 'testInteractionId';
+const headers = { fapiFinancialId, interactionId };
+
+describe('deleteAccountRequest called with authorisationServerId and fapiFinancialId', () => {
+  const username = 'user';
+  const accessToken = 'access-token';
+  const resourceServer = 'http://resource-server.com';
+  const resourcePath = `${resourceServer}/open-banking/v1.1`;
+  const accountRequestId = '88379';
+  let deleteRequestProxy;
+  let accessTokenAndResourcePathProxy;
+  let deleteAccountRequestStub;
+  let consentAccountRequestIdStub;
+
+  const setup = success => () => {
+    deleteAccountRequestStub = sinon.stub().returns(success);
+    accessTokenAndResourcePathProxy = sinon.stub().returns({ accessToken, resourcePath });
+    consentAccountRequestIdStub = sinon.stub().returns(accountRequestId);
+    deleteRequestProxy = proxyquire(
+      '../../app/setup-account-request/delete-account-request',
+      {
+        '../authorise': {
+          accessTokenAndResourcePath: accessTokenAndResourcePathProxy,
+          consentAccountRequestId: consentAccountRequestIdStub,
+        },
+        './account-requests': { deleteAccountRequest: deleteAccountRequestStub },
+      },
+    ).deleteRequest;
+  };
+
+  describe('when delete successful', () => {
+    before(setup(true));
+
+    it('returns 204 from deleteRequests call', async () => {
+      const status = await deleteRequestProxy(username, authorisationServerId, headers);
+      assert.equal(status, 204);
+      const headersWithToken = { accessToken, fapiFinancialId, interactionId };
+      assert(deleteAccountRequestStub.calledWithExactly(
+        accountRequestId,
+        resourcePath,
+        headersWithToken,
+      ));
+    });
+  });
+
+  describe('when delete not successful', () => {
+    before(setup(false));
+
+    it('throws error for now', async () => {
+      await checkErrorThrown(
+        async () => deleteRequestProxy(username, authorisationServerId, headers),
+        400, 'Bad Request',
+      );
+    });
+  });
+});

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -6,6 +6,8 @@ const { setupAccountRequest } = require('../../app/setup-account-request'); // e
 
 const authorisationServerId = 'testAuthorisationServerId';
 const fapiFinancialId = 'testFinancialId';
+const interactionId = 'testInteractionId';
+const headers = { fapiFinancialId, interactionId };
 
 describe('setupAccountRequest called with authorisationServerId and fapiFinancialId', () => {
   const accessToken = 'access-token';
@@ -39,10 +41,11 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     before(setup('AwaitingAuthorisation'));
 
     it('returns accountRequestId from postAccountRequests call', async () => {
-      const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+      const id = await setupAccountRequestProxy(authorisationServerId, headers);
       assert.equal(id, accountRequestId);
 
-      assert(accountRequestsStub.calledWithExactly(resourcePath, { accessToken, fapiFinancialId }));
+      const headersWithToken = { accessToken, fapiFinancialId, interactionId };
+      assert(accountRequestsStub.calledWithExactly(resourcePath, headersWithToken));
     });
   });
 
@@ -50,7 +53,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     before(setup('Authorised'));
 
     it('returns accountRequestId from postAccountRequests call', async () => {
-      const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
+      const id = await setupAccountRequestProxy(authorisationServerId, headers);
       assert.equal(id, accountRequestId);
     });
   });
@@ -60,7 +63,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, fapiFinancialId),
+        async () => setupAccountRequestProxy(authorisationServerId, headers),
         500, 'Account request response status: "Rejected"',
       );
     });
@@ -71,7 +74,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, fapiFinancialId),
+        async () => setupAccountRequestProxy(authorisationServerId, headers),
         500, 'Account request response status: "Revoked"',
       );
     });
@@ -82,7 +85,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, fapiFinancialId),
+        async () => setupAccountRequestProxy(authorisationServerId, headers),
         500, 'Account request response missing payload',
       );
     });

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -42,7 +42,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
       const id = await setupAccountRequestProxy(authorisationServerId, fapiFinancialId);
       assert.equal(id, accountRequestId);
 
-      assert(accountRequestsStub.calledWithExactly(resourcePath, accessToken, fapiFinancialId));
+      assert(accountRequestsStub.calledWithExactly(resourcePath, { accessToken, fapiFinancialId }));
     });
   });
 


### PR DESCRIPTION
- Add `/account-request-revoke-consent` endpoint.
- Calling endpoint:
  - Calls DELETE `/account-requests/${accountRequestId}` on ASPSP's server.
  - Deletes consent object from TPP servers consents collection.
- Some tidy up of passing headers to account request functions.