### PR TITLE
Pass headers as object to getAccountRequest

### DIFF
--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -2,6 +2,7 @@ const { get, set, remove } = require('../storage');
 const { accessTokenAndResourcePath } = require('./setup-request');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
 const { getAccountRequest } = require('../setup-account-request/account-requests');
+const uuidv4 = require('uuid/v4');
 const debug = require('debug')('debug');
 const error = require('debug')('error');
 
@@ -66,13 +67,9 @@ const getConsentStatus = async (accountRequestId, authorisationServerId) => {
 
   const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
   debug(`getConsentStatus#fapiFinancialId: ${fapiFinancialId}`);
-
-  const response = await getAccountRequest(
-    accountRequestId,
-    resourcePath,
-    accessToken,
-    fapiFinancialId,
-  );
+  const interactionId = uuidv4();
+  const headers = { accessToken, fapiFinancialId, interactionId };
+  const response = await getAccountRequest(accountRequestId, resourcePath, headers);
   debug(`getConsentStatus#getAccountRequest: ${JSON.stringify(response)}`);
 
   if (!response || !response.Data) {

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -46,6 +46,7 @@ const postAccountRequests = async (resourceServerPath, headers) => {
       .set('authorization', `Bearer ${headers.accessToken}`)
       .set('content-type', APPLICATION_JSON)
       .set('accept', APPLICATION_JSON)
+      .set('x-fapi-interaction-id', headers.interactionId)
       .set('x-fapi-financial-id', headers.fapiFinancialId)
       .send(body);
     debug(`${response.status} response for ${accountRequestsUri}`);
@@ -61,20 +62,17 @@ const postAccountRequests = async (resourceServerPath, headers) => {
  * For now only support Client Credentials Grant Type (OAuth 2.0).
  * @resourceServerPath e.g. http://example.com/open-banking/v1.1
  */
-const getAccountRequest = async (
-  accountRequestId,
-  resourceServerPath,
-  accessToken,
-  fapiFinancialId,
-) => {
+const getAccountRequest = async (accountRequestId, resourceServerPath, headers) => {
   try {
+    verifyHeaders(headers);
     const accountRequestsUri = `${resourceServerPath}/open-banking/v1.1/account-requests/${accountRequestId}`;
     log(`GET to ${accountRequestsUri}`);
     const response = await setupMutualTLS(request.get(accountRequestsUri))
-      .set('authorization', `Bearer ${accessToken}`)
+      .set('authorization', `Bearer ${headers.accessToken}`)
       .set('content-type', 'application/json; charset=utf-8')
       .set('accept', 'application/json; charset=utf-8')
-      .set('x-fapi-financial-id', fapiFinancialId);
+      .set('x-fapi-interaction-id', headers.interactionId)
+      .set('x-fapi-financial-id', headers.fapiFinancialId);
     debug(`${response.status} response for ${accountRequestsUri}`);
     return response.body;
   } catch (err) {

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -153,7 +153,8 @@ describe('filterConsented', () => {
 
 describe('getConsentStatus', () => {
   const fapiFinancialId = 'testFapiFinancialId';
-  const grantCredentialToken = 'grant-credential-access-token';
+  const interactionId = 'testInteractionId';
+  const accessToken = 'grant-credential-access-token';
   const resourcePath = 'http://resource-server.com/open-banking/v1.1';
   const getAccountRequestStub = sinon.stub();
   let getConsentStatus;
@@ -165,7 +166,7 @@ describe('getConsentStatus', () => {
         '../../app/authorise/consents.js',
         {
           './setup-request': {
-            accessTokenAndResourcePath: () => ({ accessToken: grantCredentialToken, resourcePath }),
+            accessTokenAndResourcePath: () => ({ accessToken, resourcePath }),
           },
           '../setup-account-request/account-requests': {
             getAccountRequest: getAccountRequestStub,
@@ -173,18 +174,16 @@ describe('getConsentStatus', () => {
           '../authorisation-servers': {
             fapiFinancialIdFor: () => fapiFinancialId,
           },
+          'uuid/v4': () => interactionId,
+
         },
       ));
     });
 
     it('makes remote call to get account request', async () => {
       await getConsentStatus(accountRequestId, authorisationServerId);
-      assert(getAccountRequestStub.calledWithExactly(
-        accountRequestId,
-        resourcePath,
-        grantCredentialToken,
-        fapiFinancialId,
-      ));
+      const headers = { accessToken, fapiFinancialId, interactionId };
+      assert(getAccountRequestStub.calledWithExactly(accountRequestId, resourcePath, headers));
     });
 
     it('gets the status for an existing consent', async () => {

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -62,12 +62,8 @@ describe('getAccountRequest', () => {
 
   it('returns data when 200 OK', async () => {
     const resourceServerPath = 'http://example.com/prefix';
-    const result = await getAccountRequest(
-      accountRequestId,
-      resourceServerPath,
-      accessToken,
-      fapiFinancialId,
-    );
+    const headers = { accessToken, fapiFinancialId, interactionId };
+    const result = await getAccountRequest(accountRequestId, resourceServerPath, headers);
     assert.deepEqual(result, response);
   });
 });


### PR DESCRIPTION
- Pass headers to make consistent with other account request functions.
- Verify headers and set x-fapi-interaction-id header on requests.