### PR TITLE
Remove MTLS setup from openid config endpoint call

### DIFF
--- a/app/authorisation-servers/openid-config.js
+++ b/app/authorisation-servers/openid-config.js
@@ -1,10 +1,9 @@
 const request = require('superagent');
 const log = require('debug')('log');
-const { setupMutualTLS } = require('../certs-util');
 
 const getOpenIdConfig = async (url) => {
   log(`GET ${url}`);
-  const response = await setupMutualTLS(request.get(url))
+  const response = await request.get(url)
     .set('accept', 'application/json; charset=utf-8')
     .send();
   return response.body;


### PR DESCRIPTION
- The openid config endpoints are no longer going to be MTLS protected.
- Tested successfully against reference bank.

**Note: reference bank openid conf endpoint has changed**.
Run `DEBUG=debug,log npm run updateAuthServersAndOpenIds` to update openid conf if required.