### PR TITLE
Use auth code grant access token for /payment-submissions call

### DIFF
--- a/app/session/index.js
+++ b/app/session/index.js
@@ -1,7 +1,8 @@
 const { requireAuthorization } = require('./authorization');
-const { session } = require('./session');
+const { session, getUsername } = require('./session');
 const { login } = require('./login');
 
 exports.login = login;
 exports.requireAuthorization = requireAuthorization;
 exports.session = session;
+exports.getUsername = getUsername;

--- a/app/session/session.js
+++ b/app/session/session.js
@@ -52,3 +52,4 @@ const session = (() => {
 })();
 
 exports.session = session;
+exports.getUsername = session.getUsername;

--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -1,5 +1,7 @@
 const { submitPayment } = require('./submit-payment');
+const { consentAccessToken } = require('../authorise');
 const { fapiFinancialIdFor } = require('../authorisation-servers');
+const { getUsername } = require('../session');
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -7,12 +9,18 @@ const debug = require('debug')('debug');
 const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const authServerId = req.headers['x-authorization-server-id'];
-    const fapiFinancialId = await fapiFinancialIdFor(authServerId);
+    const authorisationServerId = req.headers['x-authorization-server-id'];
+    const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
     const interactionId = req.headers['x-fapi-interaction-id'];
     const idempotencyKey = uuidv4();
-    const headers = { fapiFinancialId, idempotencyKey, interactionId };
-    const paymentSubmissionId = await submitPayment(authServerId, headers);
+    const sessionId = req.headers['authorization'];
+    const username = await getUsername(sessionId);
+    const keys = { username, authorisationServerId, scope: 'payments' };
+    const accessToken = consentAccessToken(keys);
+    const headers = {
+      fapiFinancialId, idempotencyKey, interactionId, accessToken,
+    };
+    const paymentSubmissionId = await submitPayment(authorisationServerId, headers);
 
     debug(`Payment Submission succesfully completed. Id: ${paymentSubmissionId}`);
     return res.status(201).send(); // We can't intercept a 302 !

--- a/app/submit-payment/submit-payment.js
+++ b/app/submit-payment/submit-payment.js
@@ -1,4 +1,4 @@
-const { accessTokenAndResourcePath } = require('../authorise');
+const { resourceServerPath } = require('../authorisation-servers');
 const { verifyHeaders, postPayments } = require('../setup-payment/payments');
 const { retrievePaymentDetails } = require('../setup-payment/persistence');
 
@@ -21,11 +21,10 @@ const makePayment = async (resourcePath, headers, paymentData) => {
 };
 
 const submitPayment = async (authorisationServerId, headers) => {
-  const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
-  const headersWithToken = Object.assign(headers, { accessToken });
+  const resourcePath = await resourceServerPath(authorisationServerId);
   verifyHeaders(headers);
   const paymentData = await retrievePaymentDetails(headers.interactionId);
-  const response = await makePayment(resourcePath, headersWithToken, paymentData);
+  const response = await makePayment(resourcePath, headers, paymentData);
   return response;
 };
 

--- a/test/submit-payment/payment-submission.test.js
+++ b/test/submit-payment/payment-submission.test.js
@@ -7,8 +7,9 @@ const bodyParser = require('body-parser');
 
 const fapiFinancialId = 'testFapiFinancialId';
 const authServerId = 'testAuthServerId';
+const username = 'testUsername';
 
-const setupApp = (submitPaymentStub) => {
+const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
   const { paymentSubmission } = proxyquire(
     '../../app/submit-payment/payment-submission.js',
     {
@@ -18,6 +19,12 @@ const setupApp = (submitPaymentStub) => {
       '../authorisation-servers': {
         fapiFinancialIdFor: () => fapiFinancialId,
       },
+      '../authorise': {
+        consentAccessToken: consentAccessTokenStub,
+      },
+      '../session': {
+        getUsername: () => username,
+      },
     },
   );
   const app = express();
@@ -26,8 +33,10 @@ const setupApp = (submitPaymentStub) => {
   return app;
 };
 
+
 const interactionId = 'testInteractionId';
 const PAYMENT_SUBMISSION_ID = 'PS456';
+const accessToken = 'testAccessToken';
 
 const doPost = app => request(app)
   .post('/payment-submissions')
@@ -37,7 +46,8 @@ const doPost = app => request(app)
 
 describe('/payment-submission with successful submitPayment', () => {
   const submitPaymentStub = sinon.stub().returns(PAYMENT_SUBMISSION_ID);
-  const app = setupApp(submitPaymentStub);
+  const consentAccessTokenStub = sinon.stub().returns(accessToken);
+  const app = setupApp(submitPaymentStub, consentAccessTokenStub);
 
   it('make payment submission and returns paymentSubmissionId', (done) => {
     doPost(app)
@@ -57,7 +67,8 @@ describe('/payment-submit with error thrown by submitPayment', () => {
   const error = new Error(message);
   error.status = status;
   const submitPaymentStub = sinon.stub().throws(error);
-  const app = setupApp(submitPaymentStub);
+  const consentAccessTokenStub = sinon.stub().returns(accessToken);
+  const app = setupApp(submitPaymentStub, consentAccessTokenStub);
 
   it('returns status from error', (done) => {
     doPost(app)


### PR DESCRIPTION
It was incorrect to use the client credentials access token when
calling the /payment-submissions endpoint.