### PR TITLE
Await consentAccessToken to obtain token

### DIFF
--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -16,7 +16,7 @@ const paymentSubmission = async (req, res) => {
     const sessionId = req.headers['authorization'];
     const username = await getUsername(sessionId);
     const keys = { username, authorisationServerId, scope: 'payments' };
-    const accessToken = consentAccessToken(keys);
+    const accessToken = await consentAccessToken(keys);
     const headers = {
       fapiFinancialId, idempotencyKey, interactionId, accessToken,
     };


### PR DESCRIPTION
- Fix invalid token value being sent on /payment-submissions call.
- The consentAccessToken() is async so need to await to obtain token.