### PR TITLE
Refactor extract headers - REFAPP-212 

### DIFF
--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -2,7 +2,7 @@ const request = require('superagent');
 const { setupMutualTLS } = require('../certs-util');
 const { resourceServerPath } = require('../authorisation-servers');
 const { consentAccessToken } = require('../authorise');
-const { session, extractHeaders } = require('../session');
+const { extractHeaders } = require('../session');
 const { setupResponseLogging } = require('../response-logger');
 const debug = require('debug')('debug');
 const error = require('debug')('error');
@@ -10,7 +10,9 @@ const error = require('debug')('error');
 const resourceRequestHandler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   const { authorisationServerId, headers } = await extractHeaders(req.headers);
-  const { interactionId, fapiFinancialId, sessionId } = headers;
+  const {
+    interactionId, fapiFinancialId, sessionId, username,
+  } = headers;
   let host;
   let accessToken;
   try {
@@ -23,8 +25,6 @@ const resourceRequestHandler = async (req, res) => {
   const proxiedUrl = `${host}${path}`;
   const scope = path.split('/')[3];
   try {
-    const username = await session.getUsername(sessionId);
-    debug(`username: ${username}`);
     const consentKeys = { username, authorisationServerId, scope };
     accessToken = await consentAccessToken(consentKeys);
   } catch (err) {

--- a/app/session/index.js
+++ b/app/session/index.js
@@ -1,8 +1,10 @@
 const { requireAuthorization } = require('./authorization');
 const { session, getUsername } = require('./session');
 const { login } = require('./login');
+const { extractHeaders } = require('./request-headers');
 
 exports.login = login;
 exports.requireAuthorization = requireAuthorization;
 exports.session = session;
 exports.getUsername = getUsername;
+exports.extractHeaders = extractHeaders;

--- a/app/session/request-headers.js
+++ b/app/session/request-headers.js
@@ -1,12 +1,20 @@
 const { fapiFinancialIdFor } = require('../authorisation-servers');
 const uuidv4 = require('uuid/v4');
+const { getUsername } = require('./session');
 
 const extractHeaders = async (headers) => {
   const sessionId = headers['authorization'];
   const authorisationServerId = headers['x-authorization-server-id'];
   const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
   const interactionId = uuidv4();
-  return { authorisationServerId, headers: { fapiFinancialId, interactionId, sessionId } };
+  const username = await getUsername(sessionId);
+
+  return {
+    authorisationServerId,
+    headers: {
+      fapiFinancialId, interactionId, sessionId, username,
+    },
+  };
 };
 
 exports.extractHeaders = extractHeaders;

--- a/app/session/request-headers.js
+++ b/app/session/request-headers.js
@@ -1,0 +1,12 @@
+const { fapiFinancialIdFor } = require('../authorisation-servers');
+const uuidv4 = require('uuid/v4');
+
+const extractHeaders = async (headers) => {
+  const sessionId = headers['authorization'];
+  const authorisationServerId = headers['x-authorization-server-id'];
+  const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
+  const interactionId = uuidv4();
+  return { authorisationServerId, headers: { fapiFinancialId, interactionId, sessionId } };
+};
+
+exports.extractHeaders = extractHeaders;

--- a/app/session/request-headers.js
+++ b/app/session/request-headers.js
@@ -6,7 +6,7 @@ const extractHeaders = async (headers) => {
   const sessionId = headers['authorization'];
   const authorisationServerId = headers['x-authorization-server-id'];
   const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
-  const interactionId = uuidv4();
+  const interactionId = headers['x-fapi-interaction-id'] || uuidv4();
   const username = await getUsername(sessionId);
 
   return {

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -1,7 +1,7 @@
 const { setupAccountRequest } = require('./setup-account-request');
 const { deleteRequest } = require('./delete-account-request');
 const { generateRedirectUri } = require('../authorise');
-const { session, extractHeaders } = require('../session');
+const { extractHeaders } = require('../session');
 
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
@@ -28,8 +28,7 @@ const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const username = await session.getUsername(headers.sessionId);
-    const status = await deleteRequest(username, authorisationServerId, headers);
+    const status = await deleteRequest(headers.username, authorisationServerId, headers);
     return res.sendStatus(status);
   } catch (err) {
     return res.sendStatus(400);

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -28,7 +28,7 @@ const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const status = await deleteRequest(headers.username, authorisationServerId, headers);
+    const status = await deleteRequest(authorisationServerId, headers);
     return res.sendStatus(status);
   } catch (err) {
     return res.sendStatus(400);

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -1,8 +1,8 @@
 const { accessTokenAndResourcePath, consentAccountRequestId, deleteConsent } = require('../authorise');
 const { deleteAccountRequest } = require('./account-requests');
 
-const deleteRequest = async (username, authorisationServerId, headers) => {
-  const keys = { username, authorisationServerId, scope: 'accounts' };
+const deleteRequest = async (authorisationServerId, headers) => {
+  const keys = { username: headers.username, authorisationServerId, scope: 'accounts' };
   const accountRequestId = await consentAccountRequestId(keys);
 
   if (accountRequestId) {

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -1,6 +1,6 @@
 const { setupPayment } = require('./setup-payment');
 const { generateRedirectUri } = require('../authorise');
-const { fapiFinancialIdFor } = require('../authorisation-servers');
+const { extractHeaders } = require('../session');
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -8,24 +8,19 @@ const debug = require('debug')('debug');
 const paymentAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const sessionId = req.headers['authorization'];
-    const authorisationServerId = req.headers['x-authorization-server-id'];
+    const { authorisationServerId, headers } = await extractHeaders(req.headers);
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;
-    const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
-    debug(`authorisationServerId: ${authorisationServerId}`);
-    debug(`fapiFinancialId: ${fapiFinancialId}`);
     const idempotencyKey = uuidv4();
-    const interactionId = uuidv4();
-    const headers = {
-      fapiFinancialId, idempotencyKey, interactionId, sessionId,
-    };
     const paymentId = await setupPayment(
-      authorisationServerId, headers,
+      authorisationServerId, Object.assign(headers, { idempotencyKey }),
       CreditorAccount, InstructedAmount,
     );
 
-    const uri = await generateRedirectUri(authorisationServerId, paymentId, 'openid payments', sessionId, interactionId);
+    const uri = await generateRedirectUri(
+      authorisationServerId, paymentId,
+      'openid payments', headers.sessionId, headers.interactionId,
+    );
 
     debug(`authorize URL is: ${uri}`);
     return res.status(200).send({ uri }); // We can't intercept a 302 !

--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -1,7 +1,6 @@
 const { submitPayment } = require('./submit-payment');
 const { consentAccessToken } = require('../authorise');
-const { fapiFinancialIdFor } = require('../authorisation-servers');
-const { getUsername } = require('../session');
+const { extractHeaders } = require('../session');
 const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
@@ -9,18 +8,13 @@ const debug = require('debug')('debug');
 const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const authorisationServerId = req.headers['x-authorization-server-id'];
-    const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
-    const interactionId = req.headers['x-fapi-interaction-id'];
+    const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    const { username } = headers;
     const idempotencyKey = uuidv4();
-    const sessionId = req.headers['authorization'];
-    const username = await getUsername(sessionId);
     const keys = { username, authorisationServerId, scope: 'payments' };
     const accessToken = await consentAccessToken(keys);
-    const headers = {
-      fapiFinancialId, idempotencyKey, interactionId, accessToken, sessionId,
-    };
-    const paymentSubmissionId = await submitPayment(authorisationServerId, headers);
+    const headersWithToken = Object.assign(headers, { idempotencyKey, accessToken });
+    const paymentSubmissionId = await submitPayment(authorisationServerId, headersWithToken);
 
     debug(`Payment Submission succesfully completed. Id: ${paymentSubmissionId}`);
     return res.status(201).send(); // We can't intercept a 302 !

--- a/test/session/request-headers.test.js
+++ b/test/session/request-headers.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 
 const authorisationServerId = 'testAuthorisationServerId';
 const sessionId = 'testSessionId';
+const username = 'testUsername';
 const interactionId = 'testInteractionId';
 const fapiFinancialId = 'testFapiFinancialId';
 
@@ -11,7 +12,10 @@ const { extractHeaders } = proxyquire(
   '../../app/session/request-headers.js',
   {
     '../authorisation-servers': {
-      fapiFinancialIdFor: () => fapiFinancialId,
+      fapiFinancialIdFor: async () => fapiFinancialId,
+    },
+    './session': {
+      getUsername: async () => username,
     },
     'uuid/v4': sinon.stub().returns(interactionId),
   },
@@ -26,6 +30,8 @@ describe('extractHeaders from request headers', () => {
   it('returns authorisationServerId and headers object', async () => {
     const value = await extractHeaders(requestHeaders);
     assert.equal(value.authorisationServerId, authorisationServerId);
-    assert.deepEqual(value.headers, { fapiFinancialId, interactionId, sessionId });
+    assert.deepEqual(value.headers, {
+      fapiFinancialId, interactionId, sessionId, username,
+    });
   });
 });

--- a/test/session/request-headers.test.js
+++ b/test/session/request-headers.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const authorisationServerId = 'testAuthorisationServerId';
 const sessionId = 'testSessionId';
 const username = 'testUsername';
-const interactionId = 'testInteractionId';
+const generatedInteractionId = 'testInteractionId';
 const fapiFinancialId = 'testFapiFinancialId';
 
 const { extractHeaders } = proxyquire(
@@ -17,7 +17,7 @@ const { extractHeaders } = proxyquire(
     './session': {
       getUsername: async () => username,
     },
-    'uuid/v4': sinon.stub().returns(interactionId),
+    'uuid/v4': sinon.stub().returns(generatedInteractionId),
   },
 );
 
@@ -28,10 +28,22 @@ const requestHeaders = {
 
 describe('extractHeaders from request headers', () => {
   it('returns authorisationServerId and headers object', async () => {
+    const interactionId = generatedInteractionId;
     const value = await extractHeaders(requestHeaders);
     assert.equal(value.authorisationServerId, authorisationServerId);
     assert.deepEqual(value.headers, {
       fapiFinancialId, interactionId, sessionId, username,
+    });
+  });
+
+  describe('when x-fapi-interaction-id in headers', () => {
+    it('returns headers with same interactionId', async () => {
+      const interactionId = 'existingId';
+      const value = await extractHeaders(Object.assign(requestHeaders, { 'x-fapi-interaction-id': interactionId }));
+      assert.equal(value.authorisationServerId, authorisationServerId);
+      assert.deepEqual(value.headers, {
+        fapiFinancialId, interactionId, sessionId, username,
+      });
     });
   });
 });

--- a/test/session/request-headers.test.js
+++ b/test/session/request-headers.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const authorisationServerId = 'testAuthorisationServerId';
+const sessionId = 'testSessionId';
+const interactionId = 'testInteractionId';
+const fapiFinancialId = 'testFapiFinancialId';
+
+const { extractHeaders } = proxyquire(
+  '../../app/session/request-headers.js',
+  {
+    '../authorisation-servers': {
+      fapiFinancialIdFor: () => fapiFinancialId,
+    },
+    'uuid/v4': sinon.stub().returns(interactionId),
+  },
+);
+
+const requestHeaders = {
+  'authorization': sessionId,
+  'x-authorization-server-id': authorisationServerId,
+};
+
+describe('extractHeaders from request headers', () => {
+  it('returns authorisationServerId and headers object', async () => {
+    const value = await extractHeaders(requestHeaders);
+    assert.equal(value.authorisationServerId, authorisationServerId);
+    assert.deepEqual(value.headers, { fapiFinancialId, interactionId, sessionId });
+  });
+});

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -10,21 +10,21 @@ const qs = require('qs');
 const { statePayload } = require('../../app/authorise/authorise-uri.js');
 
 const authorisationServerId = '123';
+const sessionId = 'testSession';
 const accountRequestId = 'account-request-id';
 const clientId = 'testClientId';
 const clientSecret = 'testClientSecret';
 const redirectUrl = 'http://example.com/redirect';
 const issuer = 'http://example.com';
 const jsonWebSignature = 'testSignedPayload';
-const key = 'testKey';
-const interactionId = key;
+const interactionId = 'testInteractionId';
+const interactionId2 = 'testInteractionId2';
 const fapiFinancialId = 'testFapiFinancialId';
 
 const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
   const clientCredentialsStub = sinon.stub().returns({ clientId, clientSecret });
   const createJsonWebSignatureStub = sinon.stub().returns(jsonWebSignature);
   const issuerStub = sinon.stub().returns(issuer);
-  const keyStub = sinon.stub().returns(key);
   const requestObjectSigningAlgsStub = sinon.stub().returns(['none']);
   const { generateRedirectUri } = proxyquire(
     '../../app/authorise/authorise-uri.js',
@@ -52,10 +52,13 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
       '../authorise': {
         generateRedirectUri,
       },
-      '../authorisation-servers': {
-        fapiFinancialIdFor: () => fapiFinancialId,
+      '../session': {
+        extractHeaders: () => ({
+          authorisationServerId,
+          headers: { fapiFinancialId, interactionId, sessionId },
+        }),
       },
-      'uuid/v4': keyStub,
+      'uuid/v4': sinon.stub().returns(interactionId2),
     },
   );
   const app = express();
@@ -63,8 +66,6 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
   app.post('/account-request-authorise-consent', accountRequestAuthoriseConsent);
   return app;
 };
-
-const sessionId = 'testSession';
 
 const doPost = app => request(app)
   .post('/account-request-authorise-consent')
@@ -84,7 +85,7 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
     authorisationServerId,
     sessionId,
     scope,
-    interactionId,
+    interactionId2,
     accountRequestId,
   );
   const expectedRedirectHost = 'http://example.com/authorize';
@@ -98,7 +99,7 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
   };
   const expectedState = {
     authorisationServerId,
-    interactionId,
+    interactionId: interactionId2,
     scope,
     sessionId,
     accountRequestId,

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -11,6 +11,7 @@ const { statePayload } = require('../../app/authorise/authorise-uri.js');
 
 const authorisationServerId = '123';
 const sessionId = 'testSession';
+const username = 'testUsername';
 const accountRequestId = 'account-request-id';
 const clientId = 'testClientId';
 const clientSecret = 'testClientSecret';
@@ -55,7 +56,9 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub) => {
       '../session': {
         extractHeaders: () => ({
           authorisationServerId,
-          headers: { fapiFinancialId, interactionId, sessionId },
+          headers: {
+            fapiFinancialId, interactionId, sessionId, username,
+          },
         }),
       },
       'uuid/v4': sinon.stub().returns(interactionId2),
@@ -123,7 +126,9 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
         assert.equal(header, '*');
         assert(setupAccountRequestStub.calledWithExactly(
           authorisationServerId,
-          { fapiFinancialId, interactionId, sessionId },
+          {
+            fapiFinancialId, interactionId, sessionId, username,
+          },
         ));
         done();
       });
@@ -148,7 +153,9 @@ describe('/account-request-authorise-consent with error thrown by setupAccountRe
         assert.equal(header, '*');
         assert(setupAccountRequestStub.calledWithExactly(
           authorisationServerId,
-          { fapiFinancialId, interactionId, sessionId },
+          {
+            fapiFinancialId, interactionId, sessionId, username,
+          },
         ));
         done();
       });

--- a/test/setup-account-request/delete-account-request.test.js
+++ b/test/setup-account-request/delete-account-request.test.js
@@ -6,10 +6,13 @@ const { checkErrorThrown } = require('../utils');
 const authorisationServerId = 'testAuthorisationServerId';
 const fapiFinancialId = 'testFinancialId';
 const interactionId = 'testInteractionId';
-const headers = { fapiFinancialId, interactionId };
+const sessionId = 'testSessionId';
+const username = 'testUsername';
+const headers = {
+  fapiFinancialId, interactionId, sessionId, username,
+};
 
 describe('deleteAccountRequest called with authorisationServerId and fapiFinancialId', () => {
-  const username = 'user';
   const accessToken = 'access-token';
   const resourceServer = 'http://resource-server.com';
   const resourcePath = `${resourceServer}/open-banking/v1.1`;
@@ -39,9 +42,11 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
     before(setup(true));
 
     it('returns 204 from deleteRequests call', async () => {
-      const status = await deleteRequestProxy(username, authorisationServerId, headers);
+      const status = await deleteRequestProxy(authorisationServerId, headers);
       assert.equal(status, 204);
-      const headersWithToken = { accessToken, fapiFinancialId, interactionId };
+      const headersWithToken = {
+        accessToken, fapiFinancialId, interactionId, sessionId, username,
+      };
       assert(deleteAccountRequestStub.calledWithExactly(
         accountRequestId,
         resourcePath,
@@ -55,7 +60,7 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => deleteRequestProxy(username, authorisationServerId, headers),
+        async () => deleteRequestProxy(authorisationServerId, headers),
         400, 'Bad Request',
       );
     });

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -10,6 +10,8 @@ const qs = require('qs');
 const { statePayload } = require('../../app/authorise/authorise-uri.js');
 
 const authorisationServerId = '123';
+const sessionId = 'testSessionId';
+const username = 'testUsername';
 const clientId = 'testClientId';
 const clientSecret = 'testClientSecret';
 const redirectUrl = 'http://example.com/redirect';
@@ -51,8 +53,13 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
       '../authorise': {
         generateRedirectUri,
       },
-      '../authorisation-servers': {
-        fapiFinancialIdFor: () => fapiFinancialId,
+      '../session': {
+        extractHeaders: () => ({
+          authorisationServerId,
+          headers: {
+            fapiFinancialId, interactionId, sessionId, username,
+          },
+        }),
       },
       'uuid/v4': keyStub,
     },
@@ -62,8 +69,6 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
   app.post('/payment-authorise-consent', paymentAuthoriseConsent);
   return app;
 };
-
-const sessionId = 'testSession';
 
 const doPost = app => request(app)
   .post('/payment-authorise-consent')

--- a/test/submit-payment/payment-submission.test.js
+++ b/test/submit-payment/payment-submission.test.js
@@ -6,7 +6,9 @@ const express = require('express');
 const bodyParser = require('body-parser');
 
 const fapiFinancialId = 'testFapiFinancialId';
-const authServerId = 'testAuthServerId';
+const authorisationServerId = 'testAuthServerId';
+const interactionId = 'testInteractionId';
+const sessionId = 'testSessionId';
 const username = 'testUsername';
 
 const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
@@ -16,14 +18,16 @@ const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
       './submit-payment': {
         submitPayment: submitPaymentStub,
       },
-      '../authorisation-servers': {
-        fapiFinancialIdFor: () => fapiFinancialId,
-      },
       '../authorise': {
         consentAccessToken: consentAccessTokenStub,
       },
       '../session': {
-        getUsername: () => username,
+        extractHeaders: () => ({
+          authorisationServerId,
+          headers: {
+            fapiFinancialId, interactionId, sessionId, username,
+          },
+        }),
       },
     },
   );
@@ -33,14 +37,12 @@ const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
   return app;
 };
 
-
-const interactionId = 'testInteractionId';
 const PAYMENT_SUBMISSION_ID = 'PS456';
 const accessToken = 'testAccessToken';
 
 const doPost = app => request(app)
   .post('/payment-submissions')
-  .set('x-authorization-server-id', authServerId)
+  .set('x-authorization-server-id', authorisationServerId)
   .set('x-fapi-interaction-id', interactionId)
   .send();
 


### PR DESCRIPTION
- Move extract headers logic into a separate function.
- Replace duplicated code with calls to extractHeaders function.
- Makes it easier to add new request headers later (e.g. a permissions list header).
