### PR TITLE
Return permissions from account request setup - REFAPP-212

### DIFF
--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -26,9 +26,8 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const permissions = DefaultPermissions;
-    const headersWithPermissions = Object.assign(headers, { permissions });
-    const accountRequestId = await setupAccountRequest(
+    const headersWithPermissions = Object.assign(headers, { permissions: DefaultPermissions });
+    const { accountRequestId, permissions } = await setupAccountRequest( // eslint-disable-line
       authorisationServerId,
       headersWithPermissions,
     );

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -7,11 +7,31 @@ const uuidv4 = require('uuid/v4');
 const error = require('debug')('error');
 const debug = require('debug')('debug');
 
+const DefaultPermissions = [
+  'ReadAccountsDetail',
+  'ReadBalances',
+  'ReadBeneficiariesDetail',
+  'ReadDirectDebits',
+  'ReadProducts',
+  'ReadStandingOrdersDetail',
+  'ReadTransactionsCredits',
+  'ReadTransactionsDebits',
+  'ReadTransactionsDetail',
+];
+// ExpirationDateTime: // not populated - the permissions will be open ended
+// TransactionFromDateTime: // not populated - request from the earliest available transaction
+// TransactionToDateTime: // not populated - request to the latest available transactions
+
 const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const accountRequestId = await setupAccountRequest(authorisationServerId, headers);
+    const permissions = DefaultPermissions;
+    const headersWithPermissions = Object.assign(headers, { permissions });
+    const accountRequestId = await setupAccountRequest(
+      authorisationServerId,
+      headersWithPermissions,
+    );
     const interactionId2 = uuidv4();
     const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', headers.sessionId, interactionId2);
 
@@ -37,3 +57,4 @@ const accountRequestRevokeConsent = async (req, res) => {
 
 exports.accountRequestAuthoriseConsent = accountRequestAuthoriseConsent;
 exports.accountRequestRevokeConsent = accountRequestRevokeConsent;
+exports.DefaultPermissions = DefaultPermissions;

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -5,23 +5,8 @@ const debug = require('debug')('debug');
 const assert = require('assert');
 const { setupResponseLogging } = require('../response-logger');
 
-const buildAccountRequestData = () => ({
-  Data: {
-    Permissions: [
-      'ReadAccountsDetail',
-      'ReadBalances',
-      'ReadBeneficiariesDetail',
-      'ReadDirectDebits',
-      'ReadProducts',
-      'ReadStandingOrdersDetail',
-      'ReadTransactionsCredits',
-      'ReadTransactionsDebits',
-      'ReadTransactionsDetail',
-    ],
-    // ExpirationDateTime: // not populated - the permissions will be open ended
-    // TransactionFromDateTime: // not populated - request from the earliest available transaction
-    // TransactionToDateTime: // not populated - request to the latest available transactions
-  },
+const buildAccountRequestData = Permissions => ({
+  Data: { Permissions },
   Risk: {},
 });
 
@@ -55,7 +40,7 @@ const createRequest = (requestObj, headers) => {
 const postAccountRequests = async (resourceServerPath, headers) => {
   try {
     verifyHeaders(headers);
-    const body = buildAccountRequestData();
+    const body = buildAccountRequestData(headers.permissions);
     const accountRequestsUri = `${resourceServerPath}/open-banking/v1.1/account-requests`;
     log(`POST to ${accountRequestsUri}`);
     const response = await createRequest(request.post(accountRequestsUri), headers)

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -7,8 +7,11 @@ const createRequest = async (resourcePath, headers) => {
   if (response.Data) {
     const status = response.Data.Status;
     if (status === 'AwaitingAuthorisation' || status === 'Authorised') {
-      if (response.Data.AccountRequestId) {
-        return response.Data.AccountRequestId;
+      if (response.Data.AccountRequestId && response.Data.Permissions) {
+        return {
+          accountRequestId: response.Data.AccountRequestId,
+          permissions: response.Data.Permissions,
+        };
       }
     } else {
       error = new Error(`Account request response status: "${status}"`);

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -6,7 +6,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const env = require('env-var');
 const qs = require('qs');
-
+const { DefaultPermissions } = require('../../app/setup-account-request/account-request-authorise-consent.js');
 const { statePayload } = require('../../app/authorise/authorise-uri.js');
 
 const authorisationServerId = '123';
@@ -127,7 +127,7 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
         assert(setupAccountRequestStub.calledWithExactly(
           authorisationServerId,
           {
-            fapiFinancialId, interactionId, sessionId, username,
+            fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
           },
         ));
         done();
@@ -154,7 +154,7 @@ describe('/account-request-authorise-consent with error thrown by setupAccountRe
         assert(setupAccountRequestStub.calledWithExactly(
           authorisationServerId,
           {
-            fapiFinancialId, interactionId, sessionId, username,
+            fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
           },
         ));
         done();

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -79,7 +79,8 @@ const doPost = app => request(app)
 const parseState = state => JSON.parse(Buffer.from(state, 'base64').toString('utf8'));
 
 describe('/account-request-authorise-consent with successful setupAccountRequest', () => {
-  const setupAccountRequestStub = sinon.stub().returns(accountRequestId);
+  const permissions = DefaultPermissions;
+  const setupAccountRequestStub = sinon.stub().returns({ accountRequestId, permissions });
   const authorisationEndpointStub = sinon.stub().returns('http://example.com/authorize');
   const app = setupApp(setupAccountRequestStub, authorisationEndpointStub);
 

--- a/test/setup-account-request/account-requests.test.js
+++ b/test/setup-account-request/account-requests.test.js
@@ -8,7 +8,8 @@ const assert = require('assert');
 
 const nock = require('nock');
 
-const requestBody = buildAccountRequestData();
+const permissions = ['ReadAccountsDetail'];
+const requestBody = buildAccountRequestData(permissions);
 const accountRequestId = '88379';
 const response = {
   Data: {
@@ -31,7 +32,7 @@ const fapiFinancialId = 'abc';
 const interactionId = 'xyz';
 const sessionId = 'testSessionId';
 const headers = {
-  accessToken, fapiFinancialId, interactionId, sessionId,
+  accessToken, fapiFinancialId, interactionId, sessionId, permissions,
 };
 
 describe('postAccountRequests', () => {

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -7,20 +7,26 @@ const { setupAccountRequest } = require('../../app/setup-account-request'); // e
 const authorisationServerId = 'testAuthorisationServerId';
 const fapiFinancialId = 'testFinancialId';
 const interactionId = 'testInteractionId';
-const headers = { fapiFinancialId, interactionId };
+const sessionId = 'testSessionId';
+const username = 'testUsername';
+const testPermissions = ['ReadAccountsDetail'];
+const headers = {
+  fapiFinancialId, interactionId, sessionId, username, permissions: testPermissions,
+};
 
 describe('setupAccountRequest called with authorisationServerId and fapiFinancialId', () => {
   const accessToken = 'access-token';
   const resourceServer = 'http://resource-server.com';
   const resourcePath = `${resourceServer}/open-banking/v1.1`;
-  const accountRequestId = '88379';
+  const testAccountRequest = '88379';
   let setupAccountRequestProxy;
   let accessTokenAndResourcePathProxy;
   let accountRequestsStub;
   const accountRequestsResponse = status => ({
     Data: {
-      AccountRequestId: accountRequestId,
+      AccountRequestId: testAccountRequest,
       Status: status,
+      Permissions: testPermissions,
     },
   });
 
@@ -40,11 +46,11 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   describe('when AwaitingAuthorisation', () => {
     before(setup('AwaitingAuthorisation'));
 
-    it('returns accountRequestId from postAccountRequests call', async () => {
-      const id = await setupAccountRequestProxy(authorisationServerId, headers);
-      assert.equal(id, accountRequestId);
-
-      const headersWithToken = { accessToken, fapiFinancialId, interactionId };
+    it('returns { accountRequestId, permissions } from postAccountRequests call', async () => {
+      const { accountRequestId, permissions } = await setupAccountRequestProxy(authorisationServerId, headers); // eslint-disable-line
+      assert.equal(accountRequestId, testAccountRequest);
+      assert.equal(permissions, testPermissions);
+      const headersWithToken = Object.assign(headers, { accessToken });
       assert(accountRequestsStub.calledWithExactly(resourcePath, headersWithToken));
     });
   });
@@ -52,9 +58,10 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
   describe('when Authorised', () => {
     before(setup('Authorised'));
 
-    it('returns accountRequestId from postAccountRequests call', async () => {
-      const id = await setupAccountRequestProxy(authorisationServerId, headers);
-      assert.equal(id, accountRequestId);
+    it('returns { accountRequestId, permissions } from postAccountRequests call', async () => {
+      const { accountRequestId, permissions } = await setupAccountRequestProxy(authorisationServerId, headers); // eslint-disable-line
+      assert.equal(accountRequestId, testAccountRequest);
+      assert.equal(permissions, testPermissions);
     });
   });
 


### PR DESCRIPTION
- Pass account permissions in headers object.
- In future we may allow permissions to be set by client via a request header.
- Return permissions from ASPSP response to account request setup.