### PR TITLE
REFAPP-222 Add authorisation server id to TPP server response log.

### DIFF
--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -82,8 +82,11 @@ const getConsentStatus = async (accountRequestId, authorisationServerId, session
   const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
   debug(`getConsentStatus#fapiFinancialId: ${fapiFinancialId}`);
   const interactionId = uuidv4();
+  // const headers = {
+  //   accessToken, fapiFinancialId, interactionId, sessionId,
+  // };
   const headers = {
-    accessToken, fapiFinancialId, interactionId, sessionId,
+    accessToken, fapiFinancialId, interactionId, sessionId, authorisationServerId,
   };
   const response = await getAccountRequest(accountRequestId, resourcePath, headers);
   debug(`getConsentStatus#getAccountRequest: ${JSON.stringify(response)}`);

--- a/app/authorise/consents.js
+++ b/app/authorise/consents.js
@@ -82,9 +82,6 @@ const getConsentStatus = async (accountRequestId, authorisationServerId, session
   const fapiFinancialId = await fapiFinancialIdFor(authorisationServerId);
   debug(`getConsentStatus#fapiFinancialId: ${fapiFinancialId}`);
   const interactionId = uuidv4();
-  // const headers = {
-  //   accessToken, fapiFinancialId, interactionId, sessionId,
-  // };
   const headers = {
     accessToken, fapiFinancialId, interactionId, sessionId, authorisationServerId,
   };

--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -9,9 +9,9 @@ const error = require('debug')('error');
 
 const resourceRequestHandler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  const { authorisationServerId, headers } = await extractHeaders(req.headers);
+  const { headers } = await extractHeaders(req.headers);
   const {
-    interactionId, fapiFinancialId, sessionId, username,
+    interactionId, fapiFinancialId, sessionId, username, authorisationServerId,
   } = headers;
   let host;
   let accessToken;
@@ -47,7 +47,12 @@ const resourceRequestHandler = async (req, res) => {
       .set('Accept', 'application/json')
       .set('x-fapi-financial-id', fapiFinancialId)
       .set('x-fapi-interaction-id', interactionId);
-    setupResponseLogging(call, { interactionId, sessionId, permissions });
+    setupResponseLogging(call, {
+      interactionId,
+      sessionId,
+      permissions,
+      authorisationServerId,
+    });
     const response = await call.send();
     debug(`response.status ${response.status}`);
     debug(`response.body ${JSON.stringify(response.body)}`);

--- a/app/request-data/ob-proxy.js
+++ b/app/request-data/ob-proxy.js
@@ -9,10 +9,9 @@ const error = require('debug')('error');
 
 const resourceRequestHandler = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  const { headers } = await extractHeaders(req.headers);
   const {
     interactionId, fapiFinancialId, sessionId, username, authorisationServerId,
-  } = headers;
+  } = await extractHeaders(req.headers);
   let host;
   let accessToken;
   let permissions;

--- a/app/response-logger.js
+++ b/app/response-logger.js
@@ -13,6 +13,7 @@ const setupResponseLogging = (requestObj, extras) => {
   if (process.env.NODE_ENV !== 'test' && process.env.LOG_ASPSP_RESPONSES === 'true') {
     assert.ok(extras.sessionId, 'sessionId missing from setupResponseLogging call');
     assert.ok(extras.interactionId, 'interactionId missing from setupResponseLogging call');
+    assert.ok(extras.interactionId, 'interactionId missing from setupResponseLogging call');
     const requestId = `${Date.now()}-${Math.random()}`.replace('0.', '');
     requestObj.use(superagentLogger(logger, requestId, extras));
   }

--- a/app/response-logger.js
+++ b/app/response-logger.js
@@ -13,7 +13,7 @@ const setupResponseLogging = (requestObj, extras) => {
   if (process.env.NODE_ENV !== 'test' && process.env.LOG_ASPSP_RESPONSES === 'true') {
     assert.ok(extras.sessionId, 'sessionId missing from setupResponseLogging call');
     assert.ok(extras.interactionId, 'interactionId missing from setupResponseLogging call');
-    assert.ok(extras.interactionId, 'interactionId missing from setupResponseLogging call');
+    assert.ok(extras.authorisationServerId, 'authorisationServerId missing from setupResponseLogging call');
     const requestId = `${Date.now()}-${Math.random()}`.replace('0.', '');
     requestObj.use(superagentLogger(logger, requestId, extras));
   }

--- a/app/session/request-headers.js
+++ b/app/session/request-headers.js
@@ -10,10 +10,7 @@ const extractHeaders = async (headers) => {
   const username = await getUsername(sessionId);
 
   return {
-    // authorisationServerId,
-    headers: {
-      authorisationServerId, fapiFinancialId, interactionId, sessionId, username,
-    },
+    authorisationServerId, fapiFinancialId, interactionId, sessionId, username,
   };
 };
 

--- a/app/session/request-headers.js
+++ b/app/session/request-headers.js
@@ -10,9 +10,9 @@ const extractHeaders = async (headers) => {
   const username = await getUsername(sessionId);
 
   return {
-    authorisationServerId,
+    // authorisationServerId,
     headers: {
-      fapiFinancialId, interactionId, sessionId, username,
+      authorisationServerId, fapiFinancialId, interactionId, sessionId, username,
     },
   };
 };

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -32,8 +32,8 @@ const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     // const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const { headers } = await extractHeaders(req.headers);
-    const { authorisationServerId, username } = headers;
+    const headers = await extractHeaders(req.headers);
+    const { authorisationServerId, username, sessionId } = headers;
     const headersWithPermissions = Object.assign({ permissions: DefaultPermissions }, headers);
     // const { accountRequestId, permissions } = await setupAccountRequest( // eslint-disable-line
     //   authorisationServerId,
@@ -41,7 +41,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
     // );
     const { accountRequestId, permissions } = await setupAccountRequest(headersWithPermissions);
     const interactionId2 = uuidv4();
-    const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', headers.sessionId, interactionId2);
+    const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', sessionId, interactionId2);
 
     debug(`authorize URL is: ${uri}`);
     await storePermissions(username, authorisationServerId, accountRequestId, permissions);
@@ -57,7 +57,7 @@ const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     // const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const { headers } = await extractHeaders(req.headers);
+    const headers = await extractHeaders(req.headers);
     // const status = await deleteRequest(authorisationServerId, headers);
     const status = await deleteRequest(headers);
     return res.sendStatus(status);

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -31,14 +31,9 @@ const storePermissions = async (username, authorisationServerId, accountRequestI
 const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
     const headers = await extractHeaders(req.headers);
     const { authorisationServerId, username, sessionId } = headers;
     const headersWithPermissions = Object.assign({ permissions: DefaultPermissions }, headers);
-    // const { accountRequestId, permissions } = await setupAccountRequest( // eslint-disable-line
-    //   authorisationServerId,
-    //   headersWithPermissions,
-    // );
     const { accountRequestId, permissions } = await setupAccountRequest(headersWithPermissions);
     const interactionId2 = uuidv4();
     const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', sessionId, interactionId2);
@@ -56,9 +51,7 @@ const accountRequestAuthoriseConsent = async (req, res) => {
 const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
     const headers = await extractHeaders(req.headers);
-    // const status = await deleteRequest(authorisationServerId, headers);
     const status = await deleteRequest(headers);
     return res.sendStatus(status);
   } catch (err) {

--- a/app/setup-account-request/account-request-authorise-consent.js
+++ b/app/setup-account-request/account-request-authorise-consent.js
@@ -31,17 +31,20 @@ const storePermissions = async (username, authorisationServerId, accountRequestI
 const accountRequestAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    const { headers } = await extractHeaders(req.headers);
+    const { authorisationServerId, username } = headers;
     const headersWithPermissions = Object.assign({ permissions: DefaultPermissions }, headers);
-    const { accountRequestId, permissions } = await setupAccountRequest( // eslint-disable-line
-      authorisationServerId,
-      headersWithPermissions,
-    );
+    // const { accountRequestId, permissions } = await setupAccountRequest( // eslint-disable-line
+    //   authorisationServerId,
+    //   headersWithPermissions,
+    // );
+    const { accountRequestId, permissions } = await setupAccountRequest(headersWithPermissions);
     const interactionId2 = uuidv4();
     const uri = await generateRedirectUri(authorisationServerId, accountRequestId, 'openid accounts', headers.sessionId, interactionId2);
 
     debug(`authorize URL is: ${uri}`);
-    await storePermissions(headers.username, authorisationServerId, accountRequestId, permissions);
+    await storePermissions(username, authorisationServerId, accountRequestId, permissions);
     return res.status(200).send({ uri }); // We can't intercept a 302 !
   } catch (err) {
     error(err);
@@ -53,8 +56,10 @@ const accountRequestAuthoriseConsent = async (req, res) => {
 const accountRequestRevokeConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const status = await deleteRequest(authorisationServerId, headers);
+    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    const { headers } = await extractHeaders(req.headers);
+    // const status = await deleteRequest(authorisationServerId, headers);
+    const status = await deleteRequest(headers);
     return res.sendStatus(status);
   } catch (err) {
     return res.sendStatus(400);

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -28,8 +28,8 @@ const setHeaders = (requestObj, headers) => requestObj
 
 const createRequest = (requestObj, headers) => {
   const req = setHeaders(setupMutualTLS(requestObj), headers);
-  const { interactionId, sessionId } = headers;
-  setupResponseLogging(req, { interactionId, sessionId });
+  const { interactionId, sessionId, authorisationServerId } = headers;
+  setupResponseLogging(req, { interactionId, sessionId, authorisationServerId });
   return req;
 };
 

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -1,8 +1,11 @@
 const { accessTokenAndResourcePath, consentAccountRequestId, deleteConsent } = require('../authorise');
 const { deleteAccountRequest } = require('./account-requests');
 
-const deleteRequest = async (authorisationServerId, headers) => {
-  const keys = { username: headers.username, authorisationServerId, scope: 'accounts' };
+// const deleteRequest = async (authorisationServerId, headers) => {
+const deleteRequest = async (headers) => {
+  const { authorisationServerId, username } = headers;
+  // const keys = { username: headers.username, authorisationServerId, scope: 'accounts' };
+  const keys = { username, authorisationServerId, scope: 'accounts' };
   const accountRequestId = await consentAccountRequestId(keys);
 
   if (accountRequestId) {

--- a/app/setup-account-request/delete-account-request.js
+++ b/app/setup-account-request/delete-account-request.js
@@ -1,10 +1,8 @@
 const { accessTokenAndResourcePath, consentAccountRequestId, deleteConsent } = require('../authorise');
 const { deleteAccountRequest } = require('./account-requests');
 
-// const deleteRequest = async (authorisationServerId, headers) => {
 const deleteRequest = async (headers) => {
   const { authorisationServerId, username } = headers;
-  // const keys = { username: headers.username, authorisationServerId, scope: 'accounts' };
   const keys = { username, authorisationServerId, scope: 'accounts' };
   const accountRequestId = await consentAccountRequestId(keys);
 

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -24,7 +24,9 @@ const createRequest = async (resourcePath, headers) => {
   throw error;
 };
 
-const setupAccountRequest = async (authorisationServerId, headers) => {
+// const setupAccountRequest = async (authorisationServerId, headers) => {
+const setupAccountRequest = async (headers) => {
+  const { authorisationServerId } = headers;
   const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);
   const headersWithToken = Object.assign({ accessToken }, headers);
   const accountRequestIdAndPermissions = await createRequest(resourcePath, headersWithToken);

--- a/app/setup-account-request/setup-account-request.js
+++ b/app/setup-account-request/setup-account-request.js
@@ -24,7 +24,6 @@ const createRequest = async (resourcePath, headers) => {
   throw error;
 };
 
-// const setupAccountRequest = async (authorisationServerId, headers) => {
 const setupAccountRequest = async (headers) => {
   const { authorisationServerId } = headers;
   const { accessToken, resourcePath } = await accessTokenAndResourcePath(authorisationServerId);

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -9,7 +9,7 @@ const paymentAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     // const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const { headers } = await extractHeaders(req.headers);
+    const headers = await extractHeaders(req.headers);
     const { authorisationServerId } = headers;
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -8,7 +8,6 @@ const debug = require('debug')('debug');
 const paymentAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
     const headers = await extractHeaders(req.headers);
     const { authorisationServerId } = headers;
     const { CreditorAccount } = req.body;

--- a/app/setup-payment/payment-authorise-consent.js
+++ b/app/setup-payment/payment-authorise-consent.js
@@ -8,7 +8,9 @@ const debug = require('debug')('debug');
 const paymentAuthoriseConsent = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    const { headers } = await extractHeaders(req.headers);
+    const { authorisationServerId } = headers;
     const { CreditorAccount } = req.body;
     const { InstructedAmount } = req.body;
     const idempotencyKey = uuidv4();

--- a/app/setup-payment/payments.js
+++ b/app/setup-payment/payments.js
@@ -22,7 +22,7 @@ const postPayments = async (resourceServerPath, paymentPathEndpoint, headers, pa
     verifyHeaders(headers);
     const paymentsUri = `${resourceServerPath}${paymentPathEndpoint}`;
     log(`POST to ${paymentsUri}`);
-    const { interactionId, sessionId } = headers;
+    const { interactionId, sessionId, authorisationServerId } = headers;
     const payment = setupMutualTLS(request.post(paymentsUri))
       .set('authorization', `Bearer ${headers.accessToken}`)
       .set('x-fapi-financial-id', headers.fapiFinancialId)
@@ -34,7 +34,7 @@ const postPayments = async (resourceServerPath, paymentPathEndpoint, headers, pa
     if (headers.customerIp) payment.set('x-fapi-customer-ip-address', headers.customerIp);
     if (headers.jwsSignature) payment.set('x-jws-signature', headers.jwsSignature);
 
-    setupResponseLogging(payment, { interactionId, sessionId });
+    setupResponseLogging(payment, { interactionId, sessionId, authorisationServerId });
     payment.send(paymentData);
     const response = await payment;
     debug(`${response.status} response for ${paymentsUri}`);

--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -8,7 +8,9 @@ const debug = require('debug')('debug');
 const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
+    const { headers } = await extractHeaders(req.headers);
+    const { authorisationServerId } = headers;
     const { username } = headers;
     const idempotencyKey = uuidv4();
     const keys = { username, authorisationServerId, scope: 'payments' };

--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -9,7 +9,7 @@ const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
     // const { authorisationServerId, headers } = await extractHeaders(req.headers);
-    const { headers } = await extractHeaders(req.headers);
+    const headers = await extractHeaders(req.headers);
     const { authorisationServerId } = headers;
     const { username } = headers;
     const idempotencyKey = uuidv4();

--- a/app/submit-payment/payment-submission.js
+++ b/app/submit-payment/payment-submission.js
@@ -8,7 +8,6 @@ const debug = require('debug')('debug');
 const paymentSubmission = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   try {
-    // const { authorisationServerId, headers } = await extractHeaders(req.headers);
     const headers = await extractHeaders(req.headers);
     const { authorisationServerId } = headers;
     const { username } = headers;

--- a/test/authorise/consents.test.js
+++ b/test/authorise/consents.test.js
@@ -216,7 +216,7 @@ describe('getConsentStatus', () => {
     it('makes remote call to get account request', async () => {
       await getConsentStatus(accountRequestId, authorisationServerId, sessionId);
       const headers = {
-        accessToken, fapiFinancialId, interactionId, sessionId,
+        accessToken, fapiFinancialId, interactionId, sessionId, authorisationServerId,
       };
       assert(getAccountRequestStub.calledWithExactly(accountRequestId, resourcePath, headers));
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -188,7 +188,6 @@ describe('Proxy', () => {
   it('returns proxy 200 response for /open-banking/v1.1/accounts with valid session', (done) => {
     login(app).end((err, res) => {
       const sessionId = res.body.sid;
-      // setTokenPayload(username, tokenPayload).then(() => {
       setConsent({
         username,
         authorisationServerId: authServerId,

--- a/test/session/request-headers.test.js
+++ b/test/session/request-headers.test.js
@@ -30,9 +30,10 @@ describe('extractHeaders from request headers', () => {
   it('returns authorisationServerId and headers object', async () => {
     const interactionId = generatedInteractionId;
     const value = await extractHeaders(requestHeaders);
-    assert.equal(value.authorisationServerId, authorisationServerId);
+    // assert.equal(value.authorisationServerId, authorisationServerId);
+    // assert.equal(value.authorisationServerId, authorisationServerId);
     assert.deepEqual(value.headers, {
-      fapiFinancialId, interactionId, sessionId, username,
+      fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
     });
   });
 
@@ -40,9 +41,9 @@ describe('extractHeaders from request headers', () => {
     it('returns headers with same interactionId', async () => {
       const interactionId = 'existingId';
       const value = await extractHeaders(Object.assign({ 'x-fapi-interaction-id': interactionId }, requestHeaders));
-      assert.equal(value.authorisationServerId, authorisationServerId);
+      // assert.equal(value.authorisationServerId, authorisationServerId);
       assert.deepEqual(value.headers, {
-        fapiFinancialId, interactionId, sessionId, username,
+        fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
       });
     });
   });

--- a/test/session/request-headers.test.js
+++ b/test/session/request-headers.test.js
@@ -29,10 +29,10 @@ const requestHeaders = {
 describe('extractHeaders from request headers', () => {
   it('returns authorisationServerId and headers object', async () => {
     const interactionId = generatedInteractionId;
-    const value = await extractHeaders(requestHeaders);
+    const headers = await extractHeaders(requestHeaders);
     // assert.equal(value.authorisationServerId, authorisationServerId);
     // assert.equal(value.authorisationServerId, authorisationServerId);
-    assert.deepEqual(value.headers, {
+    assert.deepEqual(headers, {
       fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
     });
   });
@@ -40,9 +40,9 @@ describe('extractHeaders from request headers', () => {
   describe('when x-fapi-interaction-id in headers', () => {
     it('returns headers with same interactionId', async () => {
       const interactionId = 'existingId';
-      const value = await extractHeaders(Object.assign({ 'x-fapi-interaction-id': interactionId }, requestHeaders));
+      const headers = await extractHeaders(Object.assign({ 'x-fapi-interaction-id': interactionId }, requestHeaders));
       // assert.equal(value.authorisationServerId, authorisationServerId);
-      assert.deepEqual(value.headers, {
+      assert.deepEqual(headers, {
         fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
       });
     });

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -56,9 +56,9 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub, setConsent
       },
       '../session': {
         extractHeaders: () => ({
-          authorisationServerId,
+          // authorisationServerId,
           headers: {
-            fapiFinancialId, interactionId, sessionId, username,
+            fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
           },
         }),
       },
@@ -127,12 +127,20 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
         assert.deepEqual(params, expectedParams);
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        assert(setupAccountRequestStub.calledWithExactly(
+        // assert(setupAccountRequestStub.calledWithExactly(
+        //   authorisationServerId,
+        //   {
+        //     fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
+        //   },
+        // ));
+        assert(setupAccountRequestStub.calledWithExactly({
+          fapiFinancialId,
+          interactionId,
+          sessionId,
+          username,
+          permissions: DefaultPermissions,
           authorisationServerId,
-          {
-            fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
-          },
-        ));
+        }));
         const keys = { username, authorisationServerId, scope: 'accounts' };
         const payload = { accountRequestId, permissions };
         assert(setConsentStub.calledWithExactly(keys, payload));
@@ -158,12 +166,20 @@ describe('/account-request-authorise-consent with error thrown by setupAccountRe
         assert.deepEqual(r.body, { message });
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        assert(setupAccountRequestStub.calledWithExactly(
+        // assert(setupAccountRequestStub.calledWithExactly(
+        //   authorisationServerId,
+        //   {
+        //     fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
+        //   },
+        // ));
+        assert(setupAccountRequestStub.calledWithExactly({
+          fapiFinancialId,
+          interactionId,
+          sessionId,
+          username,
+          permissions: DefaultPermissions,
           authorisationServerId,
-          {
-            fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
-          },
-        ));
+        }));
         assert.equal(setConsentStub.called, false);
         done();
       });

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -157,12 +157,6 @@ describe('/account-request-authorise-consent with error thrown by setupAccountRe
         assert.deepEqual(r.body, { message });
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        // assert(setupAccountRequestStub.calledWithExactly(
-        //   authorisationServerId,
-        //   {
-        //     fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
-        //   },
-        // ));
         assert(setupAccountRequestStub.calledWithExactly({
           fapiFinancialId,
           interactionId,

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -56,7 +56,6 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub, setConsent
       },
       '../session': {
         extractHeaders: () => ({
-          // authorisationServerId,
           fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
         }),
       },
@@ -125,12 +124,6 @@ describe('/account-request-authorise-consent with successful setupAccountRequest
         assert.deepEqual(params, expectedParams);
         const header = r.headers['access-control-allow-origin'];
         assert.equal(header, '*');
-        // assert(setupAccountRequestStub.calledWithExactly(
-        //   authorisationServerId,
-        //   {
-        //     fapiFinancialId, interactionId, sessionId, username, permissions: DefaultPermissions,
-        //   },
-        // ));
         assert(setupAccountRequestStub.calledWithExactly({
           fapiFinancialId,
           interactionId,

--- a/test/setup-account-request/account-request-authorise-consent.test.js
+++ b/test/setup-account-request/account-request-authorise-consent.test.js
@@ -57,9 +57,7 @@ const setupApp = (setupAccountRequestStub, authorisationEndpointStub, setConsent
       '../session': {
         extractHeaders: () => ({
           // authorisationServerId,
-          headers: {
-            fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
-          },
+          fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
         }),
       },
       'uuid/v4': sinon.stub().returns(interactionId2),

--- a/test/setup-account-request/delete-account-request.test.js
+++ b/test/setup-account-request/delete-account-request.test.js
@@ -9,7 +9,7 @@ const interactionId = 'testInteractionId';
 const sessionId = 'testSessionId';
 const username = 'testUsername';
 const headers = {
-  fapiFinancialId, interactionId, sessionId, username,
+  fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
 };
 
 describe('deleteAccountRequest called with authorisationServerId and fapiFinancialId', () => {
@@ -42,10 +42,14 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
     before(setup(true));
 
     it('returns 204 from deleteRequests call', async () => {
-      const status = await deleteRequestProxy(authorisationServerId, headers);
+      // const status = await deleteRequestProxy(authorisationServerId, headers);
+      const status = await deleteRequestProxy(headers);
       assert.equal(status, 204);
+      // const headersWithToken = {
+      //   accessToken, fapiFinancialId, interactionId, sessionId, username,
+      // };
       const headersWithToken = {
-        accessToken, fapiFinancialId, interactionId, sessionId, username,
+        accessToken, fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
       };
       assert(deleteAccountRequestStub.calledWithExactly(
         accountRequestId,
@@ -60,7 +64,8 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => deleteRequestProxy(authorisationServerId, headers),
+        // async () => deleteRequestProxy(authorisationServerId, headers),
+        async () => deleteRequestProxy(headers),
         400, 'Bad Request',
       );
     });

--- a/test/setup-account-request/delete-account-request.test.js
+++ b/test/setup-account-request/delete-account-request.test.js
@@ -42,12 +42,8 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
     before(setup(true));
 
     it('returns 204 from deleteRequests call', async () => {
-      // const status = await deleteRequestProxy(authorisationServerId, headers);
       const status = await deleteRequestProxy(headers);
       assert.equal(status, 204);
-      // const headersWithToken = {
-      //   accessToken, fapiFinancialId, interactionId, sessionId, username,
-      // };
       const headersWithToken = {
         accessToken, fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
       };
@@ -64,7 +60,6 @@ describe('deleteAccountRequest called with authorisationServerId and fapiFinanci
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        // async () => deleteRequestProxy(authorisationServerId, headers),
         async () => deleteRequestProxy(headers),
         400, 'Bad Request',
       );

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -11,7 +11,12 @@ const sessionId = 'testSessionId';
 const username = 'testUsername';
 const testPermissions = ['ReadAccountsDetail'];
 const headers = {
-  fapiFinancialId, interactionId, sessionId, username, permissions: testPermissions,
+  fapiFinancialId,
+  interactionId,
+  sessionId,
+  username,
+  permissions: testPermissions,
+  authorisationServerId,
 };
 
 describe('setupAccountRequest called with authorisationServerId and fapiFinancialId', () => {
@@ -47,7 +52,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     before(setup('AwaitingAuthorisation'));
 
     it('returns { accountRequestId, permissions } from postAccountRequests call', async () => {
-      const { accountRequestId, permissions } = await setupAccountRequestProxy(authorisationServerId, headers); // eslint-disable-line
+      const { accountRequestId, permissions } = await setupAccountRequestProxy(headers); // eslint-disable-line
       assert.equal(accountRequestId, testAccountRequest);
       assert.equal(permissions, testPermissions);
       const headersWithToken = Object.assign({ accessToken }, headers);
@@ -59,7 +64,7 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
     before(setup('Authorised'));
 
     it('returns { accountRequestId, permissions } from postAccountRequests call', async () => {
-      const { accountRequestId, permissions } = await setupAccountRequestProxy(authorisationServerId, headers); // eslint-disable-line
+      const { accountRequestId, permissions } = await setupAccountRequestProxy(headers); // eslint-disable-line
       assert.equal(accountRequestId, testAccountRequest);
       assert.equal(permissions, testPermissions);
     });
@@ -70,7 +75,8 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, headers),
+        // async () => setupAccountRequestProxy(authorisationServerId, headers),
+        async () => setupAccountRequestProxy(headers),
         500, 'Account request response status: "Rejected"',
       );
     });
@@ -81,7 +87,8 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, headers),
+        // async () => setupAccountRequestProxy(authorisationServerId, headers),
+        async () => setupAccountRequestProxy(headers),
         500, 'Account request response status: "Revoked"',
       );
     });
@@ -92,7 +99,8 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error', async () => {
       await checkErrorThrown(
-        async () => setupAccountRequestProxy(authorisationServerId, headers),
+        // async () => setupAccountRequestProxy(authorisationServerId, headers),
+        async () => setupAccountRequestProxy(headers),
         500, 'Account request response missing payload',
       );
     });

--- a/test/setup-account-request/setup-account-request.test.js
+++ b/test/setup-account-request/setup-account-request.test.js
@@ -75,7 +75,6 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        // async () => setupAccountRequestProxy(authorisationServerId, headers),
         async () => setupAccountRequestProxy(headers),
         500, 'Account request response status: "Rejected"',
       );
@@ -87,7 +86,6 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error for now', async () => {
       await checkErrorThrown(
-        // async () => setupAccountRequestProxy(authorisationServerId, headers),
         async () => setupAccountRequestProxy(headers),
         500, 'Account request response status: "Revoked"',
       );
@@ -99,7 +97,6 @@ describe('setupAccountRequest called with authorisationServerId and fapiFinancia
 
     it('throws error', async () => {
       await checkErrorThrown(
-        // async () => setupAccountRequestProxy(authorisationServerId, headers),
         async () => setupAccountRequestProxy(headers),
         500, 'Account request response missing payload',
       );

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -55,10 +55,6 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
       },
       '../session': {
         extractHeaders: () => ({
-          // authorisationServerId,
-          // headers: {
-          //   fapiFinancialId, interactionId, sessionId, username,
-          // },
           fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
         }),
       },

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -59,9 +59,7 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
           // headers: {
           //   fapiFinancialId, interactionId, sessionId, username,
           // },
-          headers: {
-            fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
-          },
+          fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
         }),
       },
       'uuid/v4': keyStub,

--- a/test/setup-payment/payment-authorise-consent.test.js
+++ b/test/setup-payment/payment-authorise-consent.test.js
@@ -55,9 +55,12 @@ const setupApp = (setupPaymentStub, authorisationEndpointStub) => {
       },
       '../session': {
         extractHeaders: () => ({
-          authorisationServerId,
+          // authorisationServerId,
+          // headers: {
+          //   fapiFinancialId, interactionId, sessionId, username,
+          // },
           headers: {
-            fapiFinancialId, interactionId, sessionId, username,
+            fapiFinancialId, interactionId, sessionId, username, authorisationServerId,
           },
         }),
       },

--- a/test/submit-payment/payment-submission.test.js
+++ b/test/submit-payment/payment-submission.test.js
@@ -22,12 +22,6 @@ const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
         consentAccessToken: consentAccessTokenStub,
       },
       '../session': {
-        // extractHeaders: () => ({
-        //   authorisationServerId,
-        //   headers: {
-        //     fapiFinancialId, interactionId, sessionId, username,
-        //   },
-        // }),
         extractHeaders: () => ({
           fapiFinancialId, interactionId, sessionId, username,
         }),

--- a/test/submit-payment/payment-submission.test.js
+++ b/test/submit-payment/payment-submission.test.js
@@ -22,11 +22,14 @@ const setupApp = (submitPaymentStub, consentAccessTokenStub) => {
         consentAccessToken: consentAccessTokenStub,
       },
       '../session': {
+        // extractHeaders: () => ({
+        //   authorisationServerId,
+        //   headers: {
+        //     fapiFinancialId, interactionId, sessionId, username,
+        //   },
+        // }),
         extractHeaders: () => ({
-          authorisationServerId,
-          headers: {
-            fapiFinancialId, interactionId, sessionId, username,
-          },
+          fapiFinancialId, interactionId, sessionId, username,
         }),
       },
     },


### PR DESCRIPTION
Required some tidy and minor refactoring.

It now adds the `authorisationServerId` to entries in the `resource.log`.

For example:
```
{
  "name": "ob-proxy.log",
  "hostname": "Ezos-MacBook.local",
  "pid": 3766,
  "origin": "superagent",
  "req_id": "1519231934075-21437101916908774",
  "interactionId": "44394c83-e5f6-4071-901b-09bdb64de224",
  "sessionId": "910d9530-1727-11e8-ac27-45a8588a3523",
  "authorisationServerId": "aaaj4NmBD8lQxmLh2O",
  "level": 30,
  "req": {
    "method": "POST",
    "url": "http://localhost:8001/open-banking/v1.1/payments",
    "path": "/open-banking/v1.1/payments",
    "headers": {
      "User-Agent": "node-superagent/3.8.0",
      "authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA",
      "x-fapi-financial-id": "aaax5nTR33811Qy",
      "x-fapi-interaction-id": "44394c83-e5f6-4071-901b-09bdb64de224",
      "x-idempotency-key": "2dfb64c6-c8d1-415b-8e3e-1c8f11c95b01",
      "content-type": "application/json; charset=utf-8",
      "accept": "application/json; charset=utf-8"
    }
  },
  "msg": "start of the request",
  "time": "2018-02-21T16:52:14.077Z",
  "v": 0
}
```