### PR TITLE
REFAPP-225 Credentials scoped by software statement

### DIFF
--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -14,6 +14,8 @@ const {
   updateClientCredentials,
   requestObjectSigningAlgs,
   idTokenSigningAlgs,
+  updateRegisteredConfig,
+  getRegisteredConfig,
 } = require('./authorisation-servers');
 
 exports.allAuthorisationServers = allAuthorisationServers;
@@ -31,3 +33,5 @@ exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;
 exports.requestObjectSigningAlgs = requestObjectSigningAlgs;
 exports.idTokenSigningAlgs = idTokenSigningAlgs;
+exports.updateRegisteredConfig = updateRegisteredConfig;
+exports.getRegisteredConfig = getRegisteredConfig;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "listAuthServers": "node ./scripts/list-auth-servers.js",
     "saveCreds": "node ./scripts/add-client-credentials.js",
     "updateAuthServersAndOpenIds": "node ./scripts/update-auth-server-and-open-id-configs",
+    "registerConfigs": "node ./scripts/register-aspsp-client-config",
     "base64-cert-or-key": "node ./scripts/base64-encode-cert-or-key"
   },
   "repository": {

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -16,6 +16,7 @@ const authServerRows = async () => {
     'OBOrganisationId',
     'clientCredentialsPresent',
     'openIdConfigPresent',
+    'registeredConfigsPresent',
   ].join('\t');
   const rows = [header];
   const list = await allAuthorisationServers();
@@ -31,6 +32,7 @@ const authServerRows = async () => {
       config ? config.OBOrganisationId : '',
       !!item.clientCredentials,
       !!item.openIdConfig,
+      !!item.registeredConfigs,
     ].join('\t');
     rows.push(line);
   });

--- a/scripts/register-aspsp-client-config.js
+++ b/scripts/register-aspsp-client-config.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const dotenv = require('dotenv');
+const debug = require('debug')('debug');
+const error = require('debug')('error');
+
+const ENVS = dotenv.load({ path: path.join(__dirname, '..', '.env') });
+debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
+
+const { updateRegisteredConfig } = require('../app/authorisation-servers');
+
+const parseArgs = rawArgs => rawArgs.reduce((acc, arg) => {
+  const [k, v = true] = arg.split('=');
+  acc[k] = v;
+  return acc;
+}, {});
+
+const parseValue = (value) => {
+  let result;
+  try {
+    result = JSON.parse(value);
+    debug(`parseValue: result: ${result}`);
+  } catch (e) {
+    debug(`parseValue: error: ${e}`);
+    result = value;
+  }
+  return result;
+};
+
+const registerAgreedConfig = async (args) => {
+  const { authServerId, field, value } = parseArgs(args);
+  if (!authServerId || !field || !value) {
+    throw new Error('authServerId, field, and value must ALL be present!');
+  }
+
+  try {
+    const config = {};
+    config[field] = parseValue(value);
+    debug(`config: ${JSON.stringify(config)}`);
+
+    await updateRegisteredConfig(authServerId, config);
+  } catch (e) {
+    error(e);
+  }
+};
+
+const exit = (env) => {
+  if (env !== 'test') {
+    process.exit();
+  }
+};
+
+registerAgreedConfig(process.argv.slice(2))
+  .then(() => exit(process.env.NODE_ENV))
+  .catch((err) => {
+    error(err);
+    exit(process.env.NODE_ENV);
+  });
+
+exports.registerAgreedConfig = registerAgreedConfig;

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -1,7 +1,10 @@
 const assert = require('assert');
 
 const { drop } = require('../../app/storage.js');
-const { ASPSP_AUTH_SERVERS_COLLECTION } = require('../../app/authorisation-servers/authorisation-servers');
+const {
+  ASPSP_AUTH_SERVERS_COLLECTION,
+  NO_SOFTWARE_STATEMENT_ID,
+} = require('../../app/authorisation-servers/authorisation-servers');
 const {
   allAuthorisationServers,
   authorisationEndpoint,
@@ -49,7 +52,12 @@ const newClientCredentials = {
   clientSecret: 'a-client-secret',
 };
 
-const clientCredentials = [Object.assign({ softwareStatementId: 'local' }, newClientCredentials)];
+const clientCredentials = [
+  Object.assign(
+    { softwareStatementId: NO_SOFTWARE_STATEMENT_ID },
+    newClientCredentials,
+  ),
+];
 
 const withOpenIdConfig = {
   id: authServerId,

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -14,8 +14,9 @@ const authorisationServersData = [
       MemberState: 'GB',
       RegistrationId: '123',
     },
-    clientCredentials: { ex: 'ample' },
+    clientCredentials: [{ ex: 'ample' }],
     openIdConfig: { ex: 'ample' },
+    registeredConfigs: [{ ex: 'ample' }],
   },
   {
     id: 'testId2',
@@ -48,7 +49,7 @@ describe('authServerRows', () => {
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
-        ['id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
+        ['id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent\tregisteredConfigsPresent'],
       );
     });
   });
@@ -62,15 +63,15 @@ describe('authServerRows', () => {
       const rows = await authServerRows();
       assert.deepEqual(
         rows[0],
-        'id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
+        'id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent\tregisteredConfigsPresent',
       );
       assert.deepEqual(
         rows[1],
-        'testId\ttestName\ttestOrg\tGB:FCA:123\ttestOrdId\ttrue\ttrue',
+        'testId\ttestName\ttestOrg\tGB:FCA:123\ttestOrdId\ttrue\ttrue\ttrue',
       );
       assert.deepEqual(
         rows[2],
-        'testId2\ttestName2\ttestOrg2\tGB:FCA:456\ttestOrdId\tfalse\tfalse',
+        'testId2\ttestName2\ttestOrg2\tGB:FCA:456\ttestOrdId\tfalse\tfalse\tfalse',
       );
     });
   });

--- a/test/scripts/register-aspsp-client-config.test.js
+++ b/test/scripts/register-aspsp-client-config.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+describe('registerAgreedConfig', () => {
+  let fakeUpdateRegisteredConfig;
+  let registerAgreedConfig;
+
+  beforeEach(async () => {
+    fakeUpdateRegisteredConfig = sinon.stub();
+    ({ registerAgreedConfig } = proxyquire(
+      '../../scripts/register-aspsp-client-config',
+      {
+        '../app/authorisation-servers': {
+          updateRegisteredConfig: fakeUpdateRegisteredConfig,
+        },
+      },
+    ));
+  });
+
+  it('registers config agreed with ASPSP for an authServerId and scoped by software statement', async () => {
+    await registerAgreedConfig(['authServerId=48fr7qwRKzA0eWKR2Se8YR', 'field=request_object_signing_alg', 'value=["PS256"]']);
+    assert(fakeUpdateRegisteredConfig.calledWithExactly(
+      '48fr7qwRKzA0eWKR2Se8YR',
+      { request_object_signing_alg: ['PS256'] },
+    ));
+  });
+});


### PR DESCRIPTION
Technically, client credentials are tied to a specific `SOFTWARE_STATEMENT_ID` that relationship was implicit.

This PR aims to make this relationship explicit. Especially,
* To clearly explain which software statement corresponds to which credentials.
* To make it easier to debug issues with upstream ASPSPs.
* To clarify how the latest Ozone updates can trigger specific features based on a `client_id` + `SOFTWARE_STATEMENT_ID` combo.
* To simplify local testing. Making swapping AuthServers and Credential features easier.