### PR TITLE
REFAPP-225 Manually Register Agreed AuthServer Client Config

### DIFF
--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -171,6 +171,16 @@ const updateClientCredentials = async (id, newCredentials) => {
   return true;
 };
 
+const updateRegisteredConfig = async (id, config) => {
+  const authServer = await getAuthServerConfig(id);
+  if (!authServer) {
+    throw new Error('Auth Server Not Found !');
+  }
+  authServer.registeredConfig = Object.assign(authServer.registeredConfig || {}, config);
+  await setAuthServerConfig(id, authServer);
+  return true;
+};
+
 const updateOpenIdConfigs = async () => {
   try {
     const list = await allAuthorisationServers();
@@ -248,5 +258,6 @@ exports.fapiFinancialIdFor = fapiFinancialIdFor;
 exports.requireAuthorisationServerId = requireAuthorisationServerId;
 exports.requestObjectSigningAlgs = requestObjectSigningAlgs;
 exports.idTokenSigningAlgs = idTokenSigningAlgs;
+exports.updateRegisteredConfig = updateRegisteredConfig;
 exports.ASPSP_AUTH_SERVERS_COLLECTION = ASPSP_AUTH_SERVERS_COLLECTION;
 exports.NO_SOFTWARE_STATEMENT_ID = NO_SOFTWARE_STATEMENT_ID;

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -254,7 +254,16 @@ const openIdConfigValue = async (id, key) => {
 
 const authorisationEndpoint = async id => openIdConfigValue(id, 'authorization_endpoint');
 
-const requestObjectSigningAlgs = async id => openIdConfigValue(id, 'request_object_signing_alg_values_supported');
+const requestObjectSigningAlgs = async (id) => {
+  let registeredConfig;
+  try {
+    registeredConfig = getRegisteredConfig(id);
+  } catch (e) {
+    registeredConfig = {};
+  }
+  return registeredConfig.request_object_signing_alg
+    || openIdConfigValue(id, 'request_object_signing_alg_values_supported');
+};
 
 const idTokenSigningAlgs = async id => openIdConfigValue(id, 'id_token_signing_alg_values_supported');
 

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -264,9 +264,8 @@ const requestObjectSigningAlgs = async (id) => {
 
   if (registeredConfig.request_object_signing_alg) {
     return registeredConfig.request_object_signing_alg;
-  } else {
-    return await openIdConfigValue(id, 'request_object_signing_alg_values_supported');
   }
+  return openIdConfigValue(id, 'request_object_signing_alg_values_supported');
 };
 
 const idTokenSigningAlgs = async id => openIdConfigValue(id, 'id_token_signing_alg_values_supported');

--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -257,12 +257,16 @@ const authorisationEndpoint = async id => openIdConfigValue(id, 'authorization_e
 const requestObjectSigningAlgs = async (id) => {
   let registeredConfig;
   try {
-    registeredConfig = getRegisteredConfig(id);
+    registeredConfig = await getRegisteredConfig(id);
   } catch (e) {
     registeredConfig = {};
   }
-  return registeredConfig.request_object_signing_alg
-    || openIdConfigValue(id, 'request_object_signing_alg_values_supported');
+
+  if (registeredConfig.request_object_signing_alg) {
+    return registeredConfig.request_object_signing_alg;
+  } else {
+    return await openIdConfigValue(id, 'request_object_signing_alg_values_supported');
+  }
 };
 
 const idTokenSigningAlgs = async id => openIdConfigValue(id, 'id_token_signing_alg_values_supported');

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -14,6 +14,7 @@ const {
   updateClientCredentials,
   requestObjectSigningAlgs,
   idTokenSigningAlgs,
+  updateRegisteredConfig,
 } = require('./authorisation-servers');
 
 exports.allAuthorisationServers = allAuthorisationServers;
@@ -31,3 +32,4 @@ exports.getClientCredentials = getClientCredentials;
 exports.updateClientCredentials = updateClientCredentials;
 exports.requestObjectSigningAlgs = requestObjectSigningAlgs;
 exports.idTokenSigningAlgs = idTokenSigningAlgs;
+exports.updateRegisteredConfig = updateRegisteredConfig;

--- a/app/authorisation-servers/index.js
+++ b/app/authorisation-servers/index.js
@@ -15,6 +15,7 @@ const {
   requestObjectSigningAlgs,
   idTokenSigningAlgs,
   updateRegisteredConfig,
+  getRegisteredConfig,
 } = require('./authorisation-servers');
 
 exports.allAuthorisationServers = allAuthorisationServers;
@@ -33,3 +34,4 @@ exports.updateClientCredentials = updateClientCredentials;
 exports.requestObjectSigningAlgs = requestObjectSigningAlgs;
 exports.idTokenSigningAlgs = idTokenSigningAlgs;
 exports.updateRegisteredConfig = updateRegisteredConfig;
+exports.getRegisteredConfig = getRegisteredConfig;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "listAuthServers": "node ./scripts/list-auth-servers.js",
     "saveCreds": "node ./scripts/add-client-credentials.js",
     "updateAuthServersAndOpenIds": "node ./scripts/update-auth-server-and-open-id-configs",
+    "registerConfigs": "node ./scripts/register-aspsp-client-config",
     "base64-cert-or-key": "node ./scripts/base64-encode-cert-or-key"
   },
   "repository": {

--- a/scripts/list-auth-servers.js
+++ b/scripts/list-auth-servers.js
@@ -16,6 +16,7 @@ const authServerRows = async () => {
     'OBOrganisationId',
     'clientCredentialsPresent',
     'openIdConfigPresent',
+    'registeredConfigsPresent',
   ].join('\t');
   const rows = [header];
   const list = await allAuthorisationServers();
@@ -31,6 +32,7 @@ const authServerRows = async () => {
       config ? config.OBOrganisationId : '',
       !!item.clientCredentials,
       !!item.openIdConfig,
+      !!item.registeredConfigs,
     ].join('\t');
     rows.push(line);
   });

--- a/scripts/register-aspsp-client-config.js
+++ b/scripts/register-aspsp-client-config.js
@@ -8,43 +8,35 @@ debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
 
 const { updateRegisteredConfig } = require('../app/authorisation-servers');
 
-const parseArgs = (rawArgs) => rawArgs.reduce((acc, arg) => {
-    const [k, v = true] = arg.split('=');
-    acc[k] = v;
-    return acc;
-  }, {});
-
-// const args = process.argv.slice(2).reduce((acc, arg) => {
-//   const [k, v = true] = arg.split('=');
-//   acc[k] = v;
-//   return acc;
-// }, {});
+const parseArgs = rawArgs => rawArgs.reduce((acc, arg) => {
+  const [k, v = true] = arg.split('=');
+  acc[k] = v;
+  return acc;
+}, {});
 
 const parseValue = (value) => {
   let result;
   try {
     result = JSON.parse(value);
-  } catch (e){
+    debug(`parseValue: result: ${result}`);
+  } catch (e) {
+    debug(`parseValue: error: ${e}`);
     result = value;
   }
-  debug(`value: ${value}`);
   return result;
 };
 
 const registerAgreedConfig = async (args) => {
   const { authServerId, field, value } = parseArgs(args);
-  // if (!parsedArgs.authServerId || !parsedArgs.field || !parsedArgs.value) {
   if (!authServerId || !field || !value) {
     throw new Error('authServerId, field, and value must ALL be present!');
   }
 
   try {
     const config = {};
-    // config[parsedArgs.field] = parseValue(parsedArgs.value);
     config[field] = parseValue(value);
     debug(`config: ${JSON.stringify(config)}`);
 
-    // await updateRegisteredConfig(parsedArgs.authServerId, config);
     await updateRegisteredConfig(authServerId, config);
   } catch (e) {
     error(e);

--- a/scripts/register-aspsp-client-config.js
+++ b/scripts/register-aspsp-client-config.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const dotenv = require('dotenv');
+const debug = require('debug')('debug');
+const error = require('debug')('error');
+
+const ENVS = dotenv.load({ path: path.join(__dirname, '..', '.env') });
+debug(`ENVs set: ${JSON.stringify(ENVS.parsed)}`);
+
+const { updateRegisteredConfig } = require('../app/authorisation-servers');
+
+const parseArgs = (rawArgs) => rawArgs.reduce((acc, arg) => {
+    const [k, v = true] = arg.split('=');
+    acc[k] = v;
+    return acc;
+  }, {});
+
+// const args = process.argv.slice(2).reduce((acc, arg) => {
+//   const [k, v = true] = arg.split('=');
+//   acc[k] = v;
+//   return acc;
+// }, {});
+
+const parseValue = (value) => {
+  let result;
+  try {
+    result = JSON.parse(value);
+  } catch (e){
+    result = value;
+  }
+  debug(`value: ${value}`);
+  return result;
+};
+
+const registerAgreedConfig = async (args) => {
+  const { authServerId, field, value } = parseArgs(args);
+  // if (!parsedArgs.authServerId || !parsedArgs.field || !parsedArgs.value) {
+  if (!authServerId || !field || !value) {
+    throw new Error('authServerId, field, and value must ALL be present!');
+  }
+
+  try {
+    const config = {};
+    // config[parsedArgs.field] = parseValue(parsedArgs.value);
+    config[field] = parseValue(value);
+    debug(`config: ${JSON.stringify(config)}`);
+
+    // await updateRegisteredConfig(parsedArgs.authServerId, config);
+    await updateRegisteredConfig(authServerId, config);
+  } catch (e) {
+    error(e);
+  }
+};
+
+const exit = (env) => {
+  if (env !== 'test') {
+    process.exit();
+  }
+};
+
+registerAgreedConfig(process.argv.slice(2))
+  .then(() => exit(process.env.NODE_ENV))
+  .catch((err) => {
+    error(err);
+    exit(process.env.NODE_ENV);
+  });
+
+exports.registerAgreedConfig = registerAgreedConfig;

--- a/test/authorisation-servers/authorisation-servers.test.js
+++ b/test/authorisation-servers/authorisation-servers.test.js
@@ -18,6 +18,7 @@ const {
   fapiFinancialIdFor,
   requestObjectSigningAlgs,
   idTokenSigningAlgs,
+  updateRegisteredConfig,
 } = require('../../app/authorisation-servers');
 
 const nock = require('nock');
@@ -59,6 +60,10 @@ const clientCredentials = [
   ),
 ];
 
+const registeredConfig = {
+  request_object_signing_alg: [ "PS256" ],
+};
+
 const withOpenIdConfig = {
   id: authServerId,
   obDirectoryConfig: {
@@ -81,6 +86,18 @@ const withClientCredsConfig = {
     OBOrganisationId: 'aaa-example-org',
   },
   clientCredentials,
+};
+
+const withRegisteredConfig = {
+  id: authServerId,
+  obDirectoryConfig: {
+    BaseApiDNSUri: baseApiDNSUri,
+    CustomerFriendlyName: 'AAA Example Bank',
+    OpenIDConfigEndPointUri: 'http://example.com/openidconfig',
+    Id: authServerId,
+    OBOrganisationId: 'aaa-example-org',
+  },
+  registeredConfig,
 };
 
 const callAndGetLatestConfig = async (fn, authorisationServerId, data) => {
@@ -170,6 +187,22 @@ describe('authorisation servers', () => {
         toUpdate,
       );
       assert.deepEqual(authServerConfig.clientCredentials, [toUpdate]);
+    });
+  });
+
+  describe('updateRegisteredConfig', () => {
+    it('before called registered config not present', async () => {
+      const list = await allAuthorisationServers();
+      const authServerConfig = list[0];
+      assert.ok(!authServerConfig.registeredConfig, 'registeredConfig not present');
+    });
+
+    it('stores registeredConfig in db', async () => {
+      await updateRegisteredConfig(authServerId, registeredConfig);
+      const list = await allAuthorisationServers();
+      const authServerConfig = list[0];
+      assert.ok(authServerConfig.registeredConfig, 'registeredConfig present');
+      assert.deepEqual(authServerConfig, withRegisteredConfig);
     });
   });
 

--- a/test/scripts/list-auth-servers.test.js
+++ b/test/scripts/list-auth-servers.test.js
@@ -14,8 +14,9 @@ const authorisationServersData = [
       MemberState: 'GB',
       RegistrationId: '123',
     },
-    clientCredentials: { ex: 'ample' },
+    clientCredentials: [{ ex: 'ample' }],
     openIdConfig: { ex: 'ample' },
+    registeredConfigs: [{ ex: 'ample' }],
   },
   {
     id: 'testId2',
@@ -48,7 +49,7 @@ describe('authServerRows', () => {
     it('returns tsv headers', async () => {
       assert.deepEqual(
         await authServerRows(),
-        ['id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent'],
+        ['id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent\tregisteredConfigsPresent'],
       );
     });
   });
@@ -62,15 +63,15 @@ describe('authServerRows', () => {
       const rows = await authServerRows();
       assert.deepEqual(
         rows[0],
-        'id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent',
+        'id\tCustomerFriendlyName\tOrganisationCommonName\tAuthority\tOBOrganisationId\tclientCredentialsPresent\topenIdConfigPresent\tregisteredConfigsPresent',
       );
       assert.deepEqual(
         rows[1],
-        'testId\ttestName\ttestOrg\tGB:FCA:123\ttestOrdId\ttrue\ttrue',
+        'testId\ttestName\ttestOrg\tGB:FCA:123\ttestOrdId\ttrue\ttrue\ttrue',
       );
       assert.deepEqual(
         rows[2],
-        'testId2\ttestName2\ttestOrg2\tGB:FCA:456\ttestOrdId\tfalse\tfalse',
+        'testId2\ttestName2\ttestOrg2\tGB:FCA:456\ttestOrdId\tfalse\tfalse\tfalse',
       );
     });
   });

--- a/test/scripts/register-aspsp-client-config.test.js
+++ b/test/scripts/register-aspsp-client-config.test.js
@@ -1,14 +1,15 @@
-const assert = require('assert'); // eslint-disable-line
-const proxyquire = require('proxyquire'); // eslint-disable-line
-const sinon = require('sinon'); //eslint-disable-line
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
 
 describe('registerAgreedConfig', () => {
-  let fakeUpdateOpenIdConfigs;
+  let fakeUpdateRegisteredConfig;
   let registerAgreedConfig;
 
   beforeEach(async () => {
     fakeUpdateRegisteredConfig = sinon.stub();
-    ({ registerAgreedConfig } = proxyquire('../../scripts/register-aspsp-client-config',
+    ({ registerAgreedConfig } = proxyquire(
+      '../../scripts/register-aspsp-client-config',
       {
         '../app/authorisation-servers': {
           updateRegisteredConfig: fakeUpdateRegisteredConfig,
@@ -17,9 +18,11 @@ describe('registerAgreedConfig', () => {
     ));
   });
 
-  it('fetches OB account service providers', () => {
-    //authServerId=48fr7qwRKzA0eWKR2Se8YR field=request_object_signing_alg value='["PS256"]'
-    registerAgreedConfig(['authServerId=48fr7qwRKzA0eWKR2Se8YR', 'field=request_object_signing_alg', "value='[\"PS256\"]'"]);
-    assert(fakeUpdateRegisteredConfig.calledWithExactly('48fr7qwRKzA0eWKR2Se8YR', { "request_object_signing_alg": ["PS256"] }));
+  it('registers config agreed with ASPSP for an authServerId and scoped by software statement', async () => {
+    await registerAgreedConfig(['authServerId=48fr7qwRKzA0eWKR2Se8YR', 'field=request_object_signing_alg', 'value=["PS256"]']);
+    assert(fakeUpdateRegisteredConfig.calledWithExactly(
+      '48fr7qwRKzA0eWKR2Se8YR',
+      { request_object_signing_alg: ['PS256'] },
+    ));
   });
 });

--- a/test/scripts/register-aspsp-client-config.test.js
+++ b/test/scripts/register-aspsp-client-config.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert'); // eslint-disable-line
+const proxyquire = require('proxyquire'); // eslint-disable-line
+const sinon = require('sinon'); //eslint-disable-line
+
+describe('registerAgreedConfig', () => {
+  let fakeUpdateOpenIdConfigs;
+  let registerAgreedConfig;
+
+  beforeEach(async () => {
+    fakeUpdateRegisteredConfig = sinon.stub();
+    ({ registerAgreedConfig } = proxyquire('../../scripts/register-aspsp-client-config',
+      {
+        '../app/authorisation-servers': {
+          updateRegisteredConfig: fakeUpdateRegisteredConfig,
+        },
+      },
+    ));
+  });
+
+  it('fetches OB account service providers', () => {
+    //authServerId=48fr7qwRKzA0eWKR2Se8YR field=request_object_signing_alg value='["PS256"]'
+    registerAgreedConfig(['authServerId=48fr7qwRKzA0eWKR2Se8YR', 'field=request_object_signing_alg', "value='[\"PS256\"]'"]);
+    assert(fakeUpdateRegisteredConfig.calledWithExactly('48fr7qwRKzA0eWKR2Se8YR', { "request_object_signing_alg": ["PS256"] }));
+  });
+});


### PR DESCRIPTION
This work bridges a gap showcased by the new `auto-login` work.

__Problem__
* Using OpenId Config params directly is not always correct.
* There's a direct mapping between a TPP's client credentials and ASPSP supported configurations for that client.
* This mapping happens either manually or very soon dynamically.

With Ozone, this has been a manual process. It highlighted an issue based on one client supporting `PS256` signing for `auto-login` during `createJsonWebSignature` while the older client supporting `none`.

__This PR__
* We now have a script that manually registers the agreed upon `AuthServer` OpenId config.
* In our particular case, `createJsonWebSignature` uses the correct signing algo.