### PR TITLE
Make clientCredentials an array on saveCreds script run

### DIFF
--- a/app/authorisation-servers/authorisation-servers.js
+++ b/app/authorisation-servers/authorisation-servers.js
@@ -161,7 +161,8 @@ const updateClientCredentials = async (id, newCredentials) => {
     throw new Error('Auth Server Not Found !');
   }
 
-  authServer.clientCredentials = authServer.clientCredentials || [];
+  authServer.clientCredentials = Array.isArray(authServer.clientCredentials) ?
+    authServer.clientCredentials : [];
   const found = authServer.clientCredentials.find(cred =>
     cred.softwareStatementId === softwareStatementId);
   const updated = Object.assign(found || { softwareStatementId }, newCredentials);


### PR DESCRIPTION
When user has old clientCredentials object replace it with an array.