### PR TITLE
Write output including validation report to kakfa - REFAPP-281

### DIFF
--- a/app/ob-util.js
+++ b/app/ob-util.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 const { setupResponseLogging } = require('./response-logger');
-const debug = require('debug')('debug');
-const util = require('util');
 const { validate, validateResponseOn } = require('./validator');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0; // To enable use of self signed certs
@@ -49,9 +47,7 @@ const createRequest = (requestObj, headers) => {
 };
 
 const validateRequestResponse = async (req, res, responseBody, details) => {
-  const { statusCode, headers, body } = await validate(req, res, details);
-  debug(`validationResponse: ${util.inspect({ statusCode, headers, body })}`);
-  const failedValidation = body.failedValidation || false;
+  const { failedValidation } = await validate(req, res, details);
   return Object.assign(responseBody, { failedValidation });
 };
 

--- a/app/setup-account-request/account-requests.js
+++ b/app/setup-account-request/account-requests.js
@@ -1,8 +1,10 @@
 const request = require('superagent');
 const { createRequest, obtainResult } = require('../ob-util');
 const log = require('debug')('log');
+const errorLog = require('debug')('error');
 const debug = require('debug')('debug');
 const assert = require('assert');
+const util = require('util');
 
 const buildAccountRequestData = Permissions => ({
   Data: { Permissions },
@@ -30,6 +32,7 @@ const postAccountRequests = async (resourceServerPath, headers) => {
     const result = await obtainResult(call, response, headers);
     return result;
   } catch (err) {
+    errorLog(util.inspect(err));
     const error = new Error(err.message);
     error.status = err.response ? err.response.status : 500;
     throw error;
@@ -50,6 +53,7 @@ const getAccountRequest = async (accountRequestId, resourceServerPath, headers) 
     debug(`${response.status} response for ${accountRequestsUri}`);
     return response.body;
   } catch (err) {
+    errorLog(util.inspect(err));
     const error = new Error(err.message);
     error.status = err.response ? err.response.status : 500;
     throw error;
@@ -69,6 +73,7 @@ const deleteAccountRequest = async (accountRequestId, resourceServerPath, header
     }
     throw new Error('Bad Request');
   } catch (err) {
+    errorLog(util.inspect(err));
     const error = new Error(err.message);
     error.status = err.response ? err.response.status : 400;
     throw error;

--- a/app/validator/index.js
+++ b/app/validator/index.js
@@ -1,6 +1,7 @@
 const { initValidatorApp, validateResponseOn } = require('./init-validator-app');
-const { validate } = require('./validate-request-response');
+const { logFormat, validate } = require('./validate-request-response');
 
 exports.initValidatorApp = initValidatorApp;
+exports.logFormat = logFormat;
 exports.validate = validate;
 exports.validateResponseOn = validateResponseOn;

--- a/app/validator/index.js
+++ b/app/validator/index.js
@@ -1,7 +1,6 @@
 const { initValidatorApp, validateResponseOn } = require('./init-validator-app');
-const { logFormat, validate } = require('./validate-request-response');
+const { validate } = require('./validate-request-response');
 
 exports.initValidatorApp = initValidatorApp;
-exports.logFormat = logFormat;
 exports.validate = validate;
 exports.validateResponseOn = validateResponseOn;

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -99,22 +99,22 @@ const writeToKafka = async (details, request, res) => {
 const validate = async (req, res, details) => {
   checkDetails(details);
   const request = reqSerializer(req);
-  let response;
+  let validationResponse;
   if (!res) {
-    response = noResponseError;
+    validationResponse = noResponseError;
   } else {
-    response = resSerializer(res);
+    validationResponse = resSerializer(res);
     const app = await validatorApp();
     debug('validate');
-    await app.handle(request, response);
-    if (response.statusCode !== 400) {
+    await app.handle(request, validationResponse);
+    if (validationResponse.statusCode !== 400) {
       debug('validation passed');
     }
   }
   if (kakfaConfigured()) {
     await writeToKafka(details, request, res);
   }
-  return response;
+  return validationResponse;
 };
 
 exports.logFormat = logFormat;

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -94,16 +94,13 @@ const writeToKafka = async (logObject) => {
 
 const runValidation = async (req, res, details) => {
   checkDetails(details);
-  const request = reqSerializer(req);
-  let validationResponse;
   if (!res) {
-    validationResponse = noResponseError;
-  } else {
-    validationResponse = resSerializer(res);
-    const app = await validatorApp();
-    debug('validate');
-    await app.handle(request, validationResponse);
+    return noResponseError;
   }
+  const validationResponse = resSerializer(res);
+  const app = await validatorApp();
+  debug('validate');
+  await app.handle(reqSerializer(req), validationResponse);
   return validationResponse;
 };
 

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -64,6 +64,24 @@ const checkDetails = (details) => {
   assert.ok(details.authorisationServerId, 'authorisationServerId missing from validate call');
 };
 
+const validationReport = (validationResponse) => {
+  let report;
+  if (validationResponse.statusCode === 400) {
+    report = JSON.parse(JSON.stringify(validationResponse.body));
+    delete report.originalResponse;
+  } else {
+    report = { validationFailed: false };
+  }
+  return report;
+};
+
+const logFormat = (request, response, details, validationResponse) => ({
+  details,
+  report: validationReport(validationResponse),
+  request: reqSerializer(request, false),
+  response: resSerializer(response),
+});
+
 const writeToKafka = async (details, request, res) => {
   try {
     const kafka = await kafkaStream();
@@ -99,4 +117,5 @@ const validate = async (req, res, details) => {
   return response;
 };
 
+exports.logFormat = logFormat;
 exports.validate = validate;

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -92,7 +92,7 @@ const writeToKafka = async (logObject) => {
   }
 };
 
-const validate = async (req, res, details) => {
+const runValidation = async (req, res, details) => {
   checkDetails(details);
   const request = reqSerializer(req);
   let validationResponse;
@@ -107,6 +107,11 @@ const validate = async (req, res, details) => {
       debug('validation passed');
     }
   }
+  return validationResponse;
+};
+
+const validate = async (req, res, details) => {
+  const validationResponse = await runValidation(req, res, details);
   if (kakfaConfigured()) {
     const logObject = logFormat(req, res, details, validationResponse);
     await writeToKafka(logObject);

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -24,18 +24,21 @@ const lowerCaseHeaders = (req) => {
 };
 
 const reqSerializer = (req) => {
+  let serialized;
   const keys = Object.keys(req);
   if (keys.includes('_data') || keys.includes('res')) {
-    return lowerCaseHeaders({
+    serialized = {
       method: req.method,
       url: req.url,
       qs: getQs(req),
       path: req.url && url.parse(req.url).pathname,
       body: req._data, // eslint-disable-line
       headers: req.header,
-    });
+    };
+  } else {
+    serialized = req;
   }
-  return lowerCaseHeaders(req);
+  return lowerCaseHeaders(serialized);
 };
 
 const resSerializer = res => ({

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -82,14 +82,10 @@ const logFormat = (request, response, details, validationResponse) => ({
   response: resSerializer(response),
 });
 
-const writeToKafka = async (details, request, res) => {
+const writeToKafka = async (logObject) => {
   try {
     const kafka = await kafkaStream();
-    await kafka.write({
-      details,
-      request: reqSerializer(request),
-      response: resSerializer(res),
-    });
+    await kafka.write(logObject);
   } catch (err) {
     errorLog(err);
     throw err;
@@ -112,7 +108,8 @@ const validate = async (req, res, details) => {
     }
   }
   if (kakfaConfigured()) {
-    await writeToKafka(details, request, res);
+    const logObject = logFormat(req, res, details, validationResponse);
+    await writeToKafka(logObject);
   }
   return validationResponse;
 };

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -23,7 +23,7 @@ const lowerCaseHeaders = (req) => {
   return req;
 };
 
-const reqSerializer = (req) => {
+const reqSerializer = (req, lowerCaseHeader = true) => {
   let serialized;
   const keys = Object.keys(req);
   if (keys.includes('_data') || keys.includes('res')) {
@@ -38,7 +38,10 @@ const reqSerializer = (req) => {
   } else {
     serialized = req;
   }
-  return lowerCaseHeaders(serialized);
+  if (lowerCaseHeader) {
+    serialized = lowerCaseHeaders(serialized);
+  }
+  return serialized;
 };
 
 const resSerializer = res => ({

--- a/app/validator/validate-request-response.js
+++ b/app/validator/validate-request-response.js
@@ -103,9 +103,6 @@ const runValidation = async (req, res, details) => {
     const app = await validatorApp();
     debug('validate');
     await app.handle(request, validationResponse);
-    if (validationResponse.statusCode !== 400) {
-      debug('validation passed');
-    }
   }
   return validationResponse;
 };

--- a/app/validator/validation-error-middleware.js
+++ b/app/validator/validation-error-middleware.js
@@ -2,6 +2,7 @@ const debug = require('debug')('debug');
 
 const validationErrorMiddleware = (err, req, res, next) => { // eslint-disable-line
   if (err.failedValidation) {
+    debug('failed validation');
     const {
       apiDeclarations,
       results,
@@ -11,7 +12,6 @@ const validationErrorMiddleware = (err, req, res, next) => { // eslint-disable-l
       warnings,
       message,
     } = err;
-    debug('failed validation');
     res.body = {
       apiDeclarations,
       errors,
@@ -22,6 +22,8 @@ const validationErrorMiddleware = (err, req, res, next) => { // eslint-disable-l
       message,
     };
     return res.status(400).end();
+  } else if (res.statusCode !== 400) {
+    debug('passed validation');
   }
   next();
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,9 +52,10 @@ nock(/example\.com/, requestHeaders)
     },
   });
 
+// bad payload to trigger validation error
 nock(/example\.com/, requestHeaders)
   .get('/open-banking/v1.1/accounts/22290/balances')
-  .reply(200, { Data: { Balance: {} }, Links: { Self: '' }, Meta: {} }); // bad payload to trigger validation error
+  .reply(200, { Data: { Balance: {} }, Links: { Self: '' }, Meta: {} });
 
 nock(/example\.com/)
   .get('/open-banking/v1.1/accounts/non-existing')

--- a/test/validator/validate-request-response.test.js
+++ b/test/validator/validate-request-response.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { validate } = require('../../app/validator/index.js');
+const { validate, logFormat } = require('../../app/validator');
 
 const { validRequest } = require('./fixtures/valid-request');
 const { validResponse } = require('./fixtures/valid-response');
@@ -70,6 +70,23 @@ describe('validate', () => {
       const expected = invalidResponse();
       assert.deepEqual(JSON.parse(originalResponse), expected.body);
       assert.deepEqual(results, validationResults);
+    });
+
+    it('and logFormat returns output object for logging', async () => {
+      const response = await validate(validRequest(), invalidResponse(), details);
+      const { failedValidation, message, results } = response.body;
+      const output = logFormat(validRequest(), invalidResponse(), details, response);
+
+      assert.deepEqual(output.request, validRequest());
+      assert.deepEqual(output.response, invalidResponse());
+      assert.deepEqual(output.details, details);
+      assert.ok(output.report, 'expect output object to contain report property');
+      const expectedReport = {
+        failedValidation,
+        message,
+        results,
+      };
+      assert.deepEqual(output.report, expectedReport);
     });
   });
 });

--- a/test/validator/validate-request-response.test.js
+++ b/test/validator/validate-request-response.test.js
@@ -7,6 +7,12 @@ const { validResponse } = require('./fixtures/valid-response');
 process.env.ACCOUNT_SWAGGER = process.env.ACCOUNT_SWAGGER || 'https://raw.githubusercontent.com/OpenBankingUK/account-info-api-spec/ee715e094a59b37aeec46aef278f528f5d89eb03/dist/v1.1/account-info-swagger.json';
 process.env.PAYMENT_SWAGGER = process.env.PAYMENT_SWAGGER || 'https://raw.githubusercontent.com/OpenBankingUK/payment-initiation-api-spec/96307a92e70e209e51710fab54164f6e8d2e61cf/dist/v1.1/payment-initiation-swagger.json';
 
+const invalidResponse = () => {
+  const response = validResponse();
+  delete response.body.Data.Balance[0].Amount;
+  return response;
+};
+
 const details = {
   interactionId: '590bcc25-517c-4caf-a140-077b41ffe095',
   sessionId: '2789f200-4960-11e8-b019-35d9f0621d63',
@@ -53,9 +59,7 @@ describe('validate', () => {
     };
 
     it('returns 400 status with json error object', async () => {
-      const invalidResponse = validResponse();
-      delete invalidResponse.body.Data.Balance[0].Amount;
-      const response = await validate(validRequest(), invalidResponse, details);
+      const response = await validate(validRequest(), invalidResponse(), details);
       const {
         failedValidation, message, originalResponse, results,
       } = response.body;
@@ -63,8 +67,7 @@ describe('validate', () => {
       assert.equal(response.statusCode, 400);
       assert(failedValidation, true);
       assert(message, 'Response validation failed: failed schema validation');
-      const expected = validResponse();
-      delete expected.body.Data.Balance[0].Amount;
+      const expected = invalidResponse();
       assert.deepEqual(JSON.parse(originalResponse), expected.body);
       assert.deepEqual(results, validationResults);
     });


### PR DESCRIPTION
- Various refactoring in prep for change.
- Write output including validation report to kakfa log.
- Previously we hadn't included validation results in the kakfa log.
- Return validation report object from `validate` function, instead of HTTP response object.