### PR TITLE
Use PORT when TPP_REF_SERVER_PORT not set to fix Heroku deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
-const port = process.env.TPP_REF_SERVER_PORT || 8003;
 const { app } = require('./app');
 const log = require('debug')('log');
 
-app.listen(port, '0.0.0.0');
-
-log(` App listening on port ${port}`);
+if (process.env.TPP_REF_SERVER_PORT) {
+  app.listen(process.env.TPP_REF_SERVER_PORT, '0.0.0.0');
+  log(` App listening on port ${process.env.TPP_REF_SERVER_PORT}`);
+} else {
+  const port = process.env.PORT || 8003;
+  app.listen(port);
+  log(` App listening on port ${port}`);
+}


### PR DESCRIPTION
- Heroku dynamically sets the `PORT` env var.
- For Heroku deployment to work we need to listen on `PORT`, and not set host to '0.0.0.0'.
- Fix is to listen on `PORT` when `TPP_REF_SERVER_PORT` env var is not set.