### PR TITLE
Include validation in docker-compose config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
      - "TRANSPORT_KEY=''"
      - "VALIDATE_RESPONSE=${VALIDATE_RESPONSE:-false}"
      - "VALIDATION_KAFKA_TOPIC=kafka-test-topic"
-     - "VALIDATION_KAFKA_BROKER=127.0.0.1:9092"
+     - "VALIDATION_KAFKA_BROKER=localhost:9092"
     links:
      - redis
      - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,9 @@ services:
      - "SOFTWARE_STATEMENT_REDIRECT_URL=http://localhost:8080/tpp/authorized"
      - "TRANSPORT_CERT=''"
      - "TRANSPORT_KEY=''"
+     - "VALIDATE_RESPONSE=${VALIDATE_RESPONSE:-false}"
+     - "VALIDATION_KAFKA_TOPIC=kafka-test-topic"
+     - "VALIDATION_KAFKA_BROKER=127.0.0.1:9092"
     links:
      - redis
      - mongo


### PR DESCRIPTION
These are the same `ENV` variables configured in `.env.sample`.

* Added missing env variables.
* Made VALIDATE_RESPONSE configurable without having to edit the docker-compose.yml.